### PR TITLE
Publish version 1.0.0 to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "react-typeahead",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "React-based typeahead and typeahead-tokenizer",
   "keywords": [
     "react",
     "typeahead",
-    "tokenizer"
+    "tokenizer",
+    "react-component"
   ],
   "homepage": "https://github.com/fmoo/react-typeahead",
   "bugs": {


### PR DESCRIPTION
I've been using this in production for a couple weeks with no issues (and other on my team have been using it too,) so I think it's about time to publish this to npm.

This bumps the version to 1.0.0 and adds the "react-component" tag to automatically be registered to http://react-components.com

@fmoo I'll need you help with `npm publish` or alternately you could add me as a collaborator on npm too.

Thanks!
