### PR TITLE
Filter object

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -51,6 +51,14 @@ var Typeahead = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      options: nextProps.options,
+      entryValue: nextProps.defaultValue,
+      visible: this.getOptionsForValue(nextProps.defaultValue, nextProps.options)
+    });
+  },
+
   getOptionsForValue: function(value, options) {
     var result = fuzzy.filter(value, options).map(function(res) {
       return res.string;

--- a/src/typeahead/selector.js
+++ b/src/typeahead/selector.js
@@ -41,11 +41,11 @@ var TypeaheadSelector = React.createClass({
 
     var results = this.props.options.map(function(result, i) {
       return (
-        <TypeaheadOption ref={result} key={result}
+        <TypeaheadOption ref={result.display} key={result.display}
           hover={this.state.selectionIndex === i}
           customClasses={this.props.customClasses}
           onClick={this._onClick.bind(this, result)}>
-          { result }
+          { result.display }
         </TypeaheadOption>
       );
     }, this);
@@ -73,7 +73,7 @@ var TypeaheadSelector = React.createClass({
 
   _nav: function(delta) {
     if (!this.props.options) {
-      return; 
+      return;
     }
     var newIndex;
     if (this.state.selectionIndex === null) {


### PR DESCRIPTION
Contains changes from #24 
**This is a breaking change** I will understand if you don't want to integrate it.

The idea is to be able to filter on objects and get these object back on selection.
For instance I can send options
```js
//TypeAhead options
var addItemOptions = _.map(this.state.items, function(item) {
  return {
    display: util.format("%s: %s", _(item.code).toString(), _(item.name).toString()),
    toString: function(){ return this.display; },
    item: item
  };
});
```
so if I have an item with code `2211` and name `Tige de métal` the string displayed in the suggestion would be `2211: Tige de métal` like: 
![image](https://cloud.githubusercontent.com/assets/4157103/5727025/f821080c-9b2d-11e4-868c-7ca4d47b893b.png)

However, when I choose this suggestion, `onOptionSelected` would send me an object with the shape
```js
{
  display: "string shown in the suggestion",
  original: {} // whatever object you gave to TypeAhead
}
```

This way I can do something like
```js
onItemSelected: function(option) {
  var id = option.original.item.id;
  // special case for custom item
  if(id === -1) {
    return this.addCustomItem();
  }
  ...
```

If compatibility is really important for you, I can try to change it so it becomes an option.