### PR TITLE
Remove window.React from source files

### DIFF
--- a/dist/react-typeahead.js
+++ b/dist/react-typeahead.js
@@ -199,7 +199,7 @@ module.exports = {
  * @jsx React.DOM
  */
 
-var React = window.React || require('react');
+var React = window.React;
 var Token = require('./token');
 var KeyEvent = require('../keyevent');
 var Typeahead = require('../typeahead');
@@ -337,12 +337,12 @@ var TypeaheadTokenizer = React.createClass({displayName: "TypeaheadTokenizer",
 module.exports = TypeaheadTokenizer;
 
 
-},{"../keyevent":3,"../typeahead":7,"./token":6,"classnames":1,"react":"react"}],6:[function(require,module,exports){
+},{"../keyevent":3,"../typeahead":7,"./token":6,"classnames":1}],6:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React || require('react');
+var React = window.React;
 var classNames = require('classnames');
 
 /**
@@ -403,12 +403,12 @@ var Token = React.createClass({displayName: "Token",
 module.exports = Token;
 
 
-},{"classnames":1,"react":"react"}],7:[function(require,module,exports){
+},{"classnames":1}],7:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React || require('react/addons');
+var React = window.React;
 var TypeaheadSelector = require('./selector');
 var KeyEvent = require('../keyevent');
 var fuzzy = require('fuzzy');
@@ -475,12 +475,12 @@ var Typeahead = React.createClass({displayName: "Typeahead",
   },
 
   _hasCustomValue: function() {
-    if (this.props.allowCustomValues > 0 && 
+    if (this.props.allowCustomValues > 0 &&
       this.state.entryValue.length >= this.props.allowCustomValues &&
       this.state.visible.indexOf(this.state.entryValue) < 0) {
       return true;
     }
-    return false; 
+    return false;
   },
 
   _getCustomValue: function() {
@@ -555,7 +555,7 @@ var Typeahead = React.createClass({displayName: "Typeahead",
   _onTab: function(event) {
     var option = this.refs.sel.state.selection ?
       this.refs.sel.state.selection : (this.state.visible.length > 0 ? this.state.visible[0] : null);
-      
+
     if (option === null && this._hasCustomValue()) {
       option = this._getCustomValue();
     }
@@ -644,12 +644,12 @@ var Typeahead = React.createClass({displayName: "Typeahead",
 module.exports = Typeahead;
 
 
-},{"../keyevent":3,"./selector":9,"classnames":1,"fuzzy":2,"react/addons":"react/addons"}],8:[function(require,module,exports){
+},{"../keyevent":3,"./selector":9,"classnames":1,"fuzzy":2}],8:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React || require('react/addons');
+var React = window.React;
 var classNames = require('classnames');
 
 /**
@@ -716,12 +716,12 @@ var TypeaheadOption = React.createClass({displayName: "TypeaheadOption",
 module.exports = TypeaheadOption;
 
 
-},{"classnames":1,"react/addons":"react/addons"}],9:[function(require,module,exports){
+},{"classnames":1}],9:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React || require('react/addons');
+var React = window.React;
 var TypeaheadOption = require('./option');
 var classNames = require('classnames');
 
@@ -850,5 +850,5 @@ var TypeaheadSelector = React.createClass({displayName: "TypeaheadSelector",
 module.exports = TypeaheadSelector;
 
 
-},{"./option":8,"classnames":1,"react/addons":"react/addons"}]},{},[4])(4)
+},{"./option":8,"classnames":1}]},{},[4])(4)
 });

--- a/dist/react-typeahead.js
+++ b/dist/react-typeahead.js
@@ -201,7 +201,7 @@ module.exports = {
  * @jsx React.DOM
  */
 
-var React = window.React;
+var React = window.React || require('react');
 var Token = require('./token');
 var KeyEvent = require('../keyevent');
 var Typeahead = require('../typeahead');
@@ -340,12 +340,12 @@ module.exports = TypeaheadTokenizer;
 
 
 
-},{"../keyevent":3,"../typeahead":7,"./token":6,"classnames":1}],6:[function(require,module,exports){
+},{"../keyevent":3,"../typeahead":7,"./token":6,"classnames":1,"react":"react"}],6:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React;
+var React = window.React || require('react');
 var classNames = require('classnames');
 
 /**
@@ -407,12 +407,12 @@ module.exports = Token;
 
 
 
-},{"classnames":1}],7:[function(require,module,exports){
+},{"classnames":1,"react":"react"}],7:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React;
+var React = window.React || require('react/addons');
 var TypeaheadSelector = require('./selector');
 var KeyEvent = require('../keyevent');
 var fuzzy = require('fuzzy');
@@ -649,12 +649,12 @@ module.exports = Typeahead;
 
 
 
-},{"../keyevent":3,"./selector":9,"classnames":1,"fuzzy":2}],8:[function(require,module,exports){
+},{"../keyevent":3,"./selector":9,"classnames":1,"fuzzy":2,"react/addons":"react/addons"}],8:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React;
+var React = window.React || require('react/addons');
 var classNames = require('classnames');
 
 /**
@@ -722,12 +722,12 @@ module.exports = TypeaheadOption;
 
 
 
-},{"classnames":1}],9:[function(require,module,exports){
+},{"classnames":1,"react/addons":"react/addons"}],9:[function(require,module,exports){
 /**
  * @jsx React.DOM
  */
 
-var React = window.React;
+var React = window.React || require('react/addons');
 var TypeaheadOption = require('./option');
 var classNames = require('classnames');
 
@@ -857,5 +857,5 @@ module.exports = TypeaheadSelector;
 
 
 
-},{"./option":8,"classnames":1}]},{},[4])(4)
+},{"./option":8,"classnames":1,"react/addons":"react/addons"}]},{},[4])(4)
 });

--- a/dist/react-typeahead.js
+++ b/dist/react-typeahead.js
@@ -184,6 +184,7 @@ KeyEvent.DOM_VK_TAB = KeyEvent.DOM_VK_TAB || 9;
 module.exports = KeyEvent;
 
 
+
 },{}],4:[function(require,module,exports){
 var Typeahead = require('./typeahead');
 var Tokenizer = require('./tokenizer');
@@ -192,6 +193,7 @@ module.exports = {
   Typeahead: Typeahead,
   Tokenizer: Tokenizer
 };
+
 
 
 },{"./tokenizer":5,"./typeahead":7}],5:[function(require,module,exports){
@@ -337,6 +339,7 @@ var TypeaheadTokenizer = React.createClass({displayName: "TypeaheadTokenizer",
 module.exports = TypeaheadTokenizer;
 
 
+
 },{"../keyevent":3,"../typeahead":7,"./token":6,"classnames":1}],6:[function(require,module,exports){
 /**
  * @jsx React.DOM
@@ -401,6 +404,7 @@ var Token = React.createClass({displayName: "Token",
 });
 
 module.exports = Token;
+
 
 
 },{"classnames":1}],7:[function(require,module,exports){
@@ -644,6 +648,7 @@ var Typeahead = React.createClass({displayName: "Typeahead",
 module.exports = Typeahead;
 
 
+
 },{"../keyevent":3,"./selector":9,"classnames":1,"fuzzy":2}],8:[function(require,module,exports){
 /**
  * @jsx React.DOM
@@ -714,6 +719,7 @@ var TypeaheadOption = React.createClass({displayName: "TypeaheadOption",
 
 
 module.exports = TypeaheadOption;
+
 
 
 },{"classnames":1}],9:[function(require,module,exports){
@@ -848,6 +854,7 @@ var TypeaheadSelector = React.createClass({displayName: "TypeaheadSelector",
 });
 
 module.exports = TypeaheadSelector;
+
 
 
 },{"./option":8,"classnames":1}]},{},[4])(4)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp": "^3.8.7",
     "gulp-mocha-phantomjs": "^0.4.0",
     "gulp-react": "^3.0.1",
+    "literalify": "^0.4.0",
     "lodash": "^2.4.1",
     "mocha": "^1.21.4",
     "react-tools": "^0.13.0",
@@ -54,14 +55,15 @@
     "test": "npm run build-test && gulp test",
     "watchify-test": "watchify test/main.js -o test/bundle.js -v",
     "build-test": "browserify test/main.js -o test/bundle.js",
-    "build": "browserify ./src/react-typeahead.js -s ReactTypeahead -i react -x react -x 'react/addons' -o ./dist/react-typeahead.js",
-    "watchify": "watchify ./src/react-typeahead.js -s ReactTypeahead -i react -x react -x 'react/addons' -o ./dist/react-typeahead.js",
+    "build": "browserify ./src/react-typeahead.js -s ReactTypeahead -o ./dist/react-typeahead.js",
+    "watchify": "watchify ./src/react-typeahead.js -s ReactTypeahead -o ./dist/react-typeahead.js",
     "lib": "gulp build",
     "prepublish": "npm run lib"
   },
   "browserify": {
     "transform": [
-      "reactify"
+      "reactify",
+      ["literalify", {"react": "window.React","react/addons": "window.React"}]
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,15 +55,14 @@
     "test": "npm run build-test && gulp test",
     "watchify-test": "watchify test/main.js -o test/bundle.js -v",
     "build-test": "browserify test/main.js -o test/bundle.js",
-    "build": "browserify ./src/react-typeahead.js -s ReactTypeahead -o ./dist/react-typeahead.js",
-    "watchify": "watchify ./src/react-typeahead.js -s ReactTypeahead -o ./dist/react-typeahead.js",
+    "build": "browserify ./src/react-typeahead.js -t reactify -t [literalify --react window.React --react/addons window.React] -s ReactTypeahead -o ./dist/react-typeahead.js",
+    "watchify": "watchify ./src/react-typeahead.js -t reactify -t [literalify --react window.React --react/addons window.React] -s ReactTypeahead -o ./dist/react-typeahead.js",
     "lib": "gulp build",
     "prepublish": "npm run lib"
   },
   "browserify": {
     "transform": [
-      "reactify",
-      ["literalify", {"react": "window.React","react/addons": "window.React"}]
+      "reactify"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,10 +55,14 @@
     "test": "npm run build-test && gulp test",
     "watchify-test": "watchify test/main.js -o test/bundle.js -v",
     "build-test": "browserify test/main.js -o test/bundle.js",
-    "build": "browserify ./src/react-typeahead.js -t reactify -t [literalify --react window.React --react/addons window.React] -s ReactTypeahead -o ./dist/react-typeahead.js",
-    "watchify": "watchify ./src/react-typeahead.js -t reactify -t [literalify --react window.React --react/addons window.React] -s ReactTypeahead -o ./dist/react-typeahead.js",
+    "build": "browserify ./src/react-typeahead.js -t reactify -t literalify -x react -x 'react/addons' -s ReactTypeahead -o ./dist/react-typeahead.js",
+    "watchify": "watchify ./src/react-typeahead.js -t reactify -t literalify -x react -x 'react/addons' -s ReactTypeahead -o ./dist/react-typeahead.js",
     "lib": "gulp build",
     "prepublish": "npm run lib"
+  },
+  "literalify": {
+    "react": "window.React || require('react')",
+    "react/addons": "window.React || require('react/addons')"
   },
   "browserify": {
     "transform": [

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -2,7 +2,7 @@
  * @jsx React.DOM
  */
 
-var React = window.React || require('react');
+var React = require('react');
 var Token = require('./token');
 var KeyEvent = require('../keyevent');
 var Typeahead = require('../typeahead');

--- a/src/tokenizer/token.js
+++ b/src/tokenizer/token.js
@@ -2,7 +2,7 @@
  * @jsx React.DOM
  */
 
-var React = window.React || require('react');
+var React = require('react');
 var classNames = require('classnames');
 
 /**

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -69,12 +69,12 @@ var Typeahead = React.createClass({
   },
 
   _hasCustomValue: function() {
-    if (this.props.allowCustomValues > 0 && 
+    if (this.props.allowCustomValues > 0 &&
       this.state.entryValue.length >= this.props.allowCustomValues &&
       this.state.visible.indexOf(this.state.entryValue) < 0) {
       return true;
     }
-    return false; 
+    return false;
   },
 
   _getCustomValue: function() {
@@ -149,7 +149,7 @@ var Typeahead = React.createClass({
   _onTab: function(event) {
     var option = this.refs.sel.state.selection ?
       this.refs.sel.state.selection : (this.state.visible.length > 0 ? this.state.visible[0] : null);
-      
+
     if (option === null && this._hasCustomValue()) {
       option = this._getCustomValue();
     }

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -2,7 +2,7 @@
  * @jsx React.DOM
  */
 
-var React = window.React || require('react/addons');
+var React = require('react/addons');
 var TypeaheadSelector = require('./selector');
 var KeyEvent = require('../keyevent');
 var fuzzy = require('fuzzy');

--- a/src/typeahead/option.js
+++ b/src/typeahead/option.js
@@ -2,7 +2,7 @@
  * @jsx React.DOM
  */
 
-var React = window.React || require('react/addons');
+var React = require('react/addons');
 var classNames = require('classnames');
 
 /**

--- a/src/typeahead/selector.js
+++ b/src/typeahead/selector.js
@@ -2,7 +2,7 @@
  * @jsx React.DOM
  */
 
-var React = window.React || require('react/addons');
+var React = require('react/addons');
 var TypeaheadOption = require('./option');
 var classNames = require('classnames');
 


### PR DESCRIPTION
This pull request removes window.React from the source files so they can be used for server side rendering with browserify & webpack.

Additionally I've updated the package.json to use `literalify` so the generated bundle keeps the original behavior.

The only thing it does not do is consider an external browserified bundle to provide React,
not sure if anybody uses such a setup though, to me it seems not :-)

I've added the generated dist to a plunker to proof the example still works:
http://embed.plnkr.co/9TNQVwHemhVElcgroXxE/preview
