### PR TITLE
reactify must be a non-dev dependency in order for Browserify to work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "classnames": "^1.2.0",
     "fuzzy": "^0.1.0",
-    "react": "^0.13.1"
+    "react": "^0.13.1",
+    "reactify": "^1.0.0"
   },
   "main": "lib/react-typeahead.js",
   "devDependencies": {
@@ -48,7 +49,6 @@
     "lodash": "^2.4.1",
     "mocha": "^1.21.4",
     "react-tools": "^0.13.0",
-    "reactify": "^1.0.0",
     "sinon": "^1.10.3",
     "watchify": "^2.2.1"
   },


### PR DESCRIPTION
This issue only crops up in CoffeeScript-based projects, where reactify
is not necessarily already installed at the top level, causing Browserify
to fail when it tries to apply the transform.