### PR TITLE
Since the publish scripts already reactify the source, Browserify needs no further transforms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,5 @@
   "literalify": {
     "react": "window.React || require('react')",
     "react/addons": "window.React || require('react/addons')"
-  },
-  "browserify": {
-    "transform": [
-      "reactify"
-    ]
   }
 }


### PR DESCRIPTION
Fixes an issue where a project that does not already include reactify (e.g. a CoffeeScript project) would throw exceptions during the build because there was no reactify module.

Replaces #58.