### PR TITLE
return modified token in callback props

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ var Tokenizer = require('react-typeahead').Tokenizer;
 React.render(
   <Tokenizer
     options={['John', 'Paul', 'George', 'Ringo']}
-    onTokenAdd={function(token) {
+    onTokenAdd={function(selectedTokens, token) {
       console.log('token added: ', token);
+      console.log('current tokens: ', selectedTokens);
     }}
   />
 );
@@ -162,12 +163,14 @@ A set of values of tokens to be loaded on first render.
 #### props.onTokenRemove
 
 Type: `Function`
+Params: `(selectedTokens, removedToken)`
 
 Event handler triggered whenever a token is removed.
 
 #### props.onTokenAdd
 
 Type: `Function`
+Params: `(selectedTokens, addedToken)`
 
 Event handler triggered whenever a token is removed.
 

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -122,7 +122,7 @@ var TypeaheadTokenizer = React.createClass({
 
     this.state.selected.splice(index, 1);
     this.setState({selected: this.state.selected});
-    this.props.onTokenRemove(this.state.selected);
+    this.props.onTokenRemove(this.state.selected, value);
     return;
   },
 
@@ -133,7 +133,7 @@ var TypeaheadTokenizer = React.createClass({
     this.state.selected.push(value);
     this.setState({selected: this.state.selected});
     this.refs.typeahead.setEntryText("");
-    this.props.onTokenAdd(this.state.selected);
+    this.props.onTokenAdd(this.state.selected, value);
   },
 
   render: function() {


### PR DESCRIPTION
Hey @fmoo,

I added the modified token to the function signature of the token modification callbacks. In my opinion, the modified token should come first, and the selectedTokens should come second, but I didn't want to introduce a non backward compatible change. According to the current readme, it appears as if this is the intended functionality, but not what the code does. Anyway, the order doesn't really matter. What do you think of this PR?

Thanks!