### PR TITLE
added Typeahead#focus and Tokenizer#focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ If not specified, it will fall back onto the semantics described in `props.displ
 
 This option is ignored if you don't specify the `name` prop. It is required if you both specify the `name` prop and are using non-string options. It is optional otherwise.
 
+### Typeahead(exposed component functions)
+
+#### typeahead.focus
+
+Focuses the typeahead input.
+
 ---
 
 ### Tokenizer(props)
@@ -202,6 +208,11 @@ Type: `Function`
 
 A function to filter the provided `options` based on the current input value. For each option, receives `(inputValue, option)`. If not supplied, defaults to [fuzzy string matching](https://github.com/mattyork/fuzzy).
 
+### Tokenizer(exposed component functions)
+
+#### tokenizer.focus
+
+Focuses the tokenizer input.
 
 ## Developing
 

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -69,6 +69,10 @@ var TypeaheadTokenizer = React.createClass({
     }
   },
 
+  focus: function(){
+    this.refs.typeahead.focus();
+  },
+
   // TODO: Support initialized tokens
   //
   _renderTokens: function() {

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -94,6 +94,10 @@ var Typeahead = React.createClass({
     this._onTextEntryUpdated();
   },
 
+  focus: function(){
+    React.findDOMNode(this.refs.entry).focus()
+  },
+
   _hasCustomValue: function() {
     if (this.props.allowCustomValues > 0 &&
       this.state.entryValue.length >= this.props.allowCustomValues &&

--- a/test/tokenizer-test.js
+++ b/test/tokenizer-test.js
@@ -71,7 +71,21 @@ describe('TypeaheadTokenizer Component', function() {
 
       TestUtils.findRenderedDOMComponentWithClass(tokens[0], 'typeahead-token');
       TestUtils.findRenderedDOMComponentWithClass(tokens[0], 'custom-token');
-      
+
+    });
+
+    describe('component functions', function() {
+      beforeEach(function() {
+        this.sinon = sinon.sandbox.create();
+      });
+      afterEach(function() {
+        this.sinon.restore();
+      });
+      it('focuses the typeahead', function() {
+        this.sinon.spy(this.component.refs.typeahead, 'focus');
+        this.component.focus();
+        assert.equal(this.component.refs.typeahead.focus.calledOnce, true)
+      });
     });
 
     describe('keyboard controls', function() {

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -129,6 +129,20 @@ describe('Typeahead Component', function() {
       });
     });
 
+    describe('component functions', function() {
+      beforeEach(function() {
+        this.sinon = sinon.sandbox.create();
+      });
+      afterEach(function() {
+        this.sinon.restore();
+      });
+      it('focuses the typeahead', function() {
+        var node = React.findDOMNode(this.component.refs.entry);
+        this.sinon.spy(node, 'focus');
+        this.component.focus();
+        assert.equal(node.focus.calledOnce, true);
+      });
+    });
   });
 
   describe('props', function() {


### PR DESCRIPTION
added two exposed component functions to focus the input.

Useful when rendering a parent component and you want to immediatly focus this input for the user

I found that `React.findDOMNode(this.tokenizer.refs.typeahead.refs.entry).focus()` was too cumbersome and brittle. I don't know if you'd rather expose the input in a more graceful way or keep the `focus` function as the only supported exposed way to access the input.