### PR TITLE
Replace TypeaheadSelector with custom Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,26 @@ If not specified, it will fall back onto the semantics described in `props.displ
 
 This option is ignored if you don't specify the `name` prop. It is required if you both specify the `name` prop and are using non-string options. It is optional otherwise.
 
+#### props.customListComponent
+
+Type: `React Component`
+
+A React Component that renders the list of typeahead results. This replaces the default list of results.
+
+This component receives the following props :
+
+##### Passed through
+
+- `props.displayOptions`
+- `props.customClasses`
+- `props.onOptionSelected`
+
+##### Created or modified
+- `props.options`
+  - This is the Typeahead's `props.options` filtered and limited to `Typeahead.props.maxVisible`.
+- `props.selectedIndex`
+  - The index of the highlighted option for rendering
+
 ---
 
 ### Tokenizer(props)

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -46,7 +46,8 @@ var Typeahead = React.createClass({
     formInputOption: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.func
-    ])
+    ]),
+    customListComponent: React.PropTypes.func
   },
 
   getDefaultProps: function() {
@@ -63,7 +64,8 @@ var Typeahead = React.createClass({
       onKeyUp: function(event) {},
       onFocus: function(event) {},
       onBlur: function(event) {},
-      filterOption: null
+      filterOption: null,
+      customListComponent: TypeaheadSelector
     };
   },
 
@@ -124,13 +126,8 @@ var Typeahead = React.createClass({
       return "";
     }
 
-    // There are no typeahead / autocomplete suggestions
-    if (!this._hasHint()) {
-      return "";
-    }
-
     return (
-      <TypeaheadSelector
+      <this.props.customListComponent
         ref="sel" options={this.state.visible}
         onOptionSelected={this._onOptionSelected}
         customValue={this._getCustomValue()}

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -47,7 +47,7 @@ var Typeahead = React.createClass({
       React.PropTypes.string,
       React.PropTypes.func
     ]),
-    customListComponent: React.PropTypes.func
+    customListComponent: React.PropTypes.element
   },
 
   getDefaultProps: function() {

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -460,5 +460,48 @@ describe('Typeahead Component', function() {
         });
       });
     });
+
+    context('customListComponent', function() {
+      before(function() {
+        ListComponent = React.createClass({
+          render: function() {
+            return <div></div>;
+          }
+        });
+
+        this.ListComponent = ListComponent;
+      })
+
+      beforeEach(function() {
+
+        this.component = TestUtils.renderIntoDocument(
+          <Typeahead
+            options={ BEATLES }
+            customListComponent={this.ListComponent}/>
+        );
+      });
+
+      it('should not show the customListComponent when the input is empty', function() {
+        var results = TestUtils.scryRenderedComponentsWithType(this.component, this.ListComponent);
+        assert.equal(0, results.length);
+      });
+
+      it('should show the customListComponent when the input is not empty', function() {
+        var input = this.component.refs.entry.getDOMNode();
+        input.value = "o";
+        TestUtils.Simulate.change(input);
+        var results = TestUtils.scryRenderedComponentsWithType(this.component, this.ListComponent);
+        assert.equal(1, results.length);
+      });
+
+      it('should no longer show the customListComponent after an option has been selected', function() {
+        var input = this.component.refs.entry.getDOMNode();
+        input.value = "o";
+        TestUtils.Simulate.change(input);
+        TestUtils.Simulate.keyDown(input, { keyCode: Keyevent.DOM_VK_TAB });
+        var results = TestUtils.scryRenderedComponentsWithType(this.component, this.ListComponent);
+        assert.equal(0, results.length);
+      });
+    })
   });
 });


### PR DESCRIPTION
This allows more customisation of the results and also simplifies the creation of a empty results message inside the customListComponent.