### PR TITLE
Specify Unique key instead of displayString

### DIFF
--- a/src/typeahead/selector.js
+++ b/src/typeahead/selector.js
@@ -54,8 +54,9 @@ var TypeaheadSelector = React.createClass({
 
     var results = this.props.options.map(function(result, i) {
       var displayString = this.props.displayOption(result, i);
+      var uniqueKey = displayString + '_' + i;
       return (
-        <TypeaheadOption ref={displayString} key={displayString}
+        <TypeaheadOption ref={uniqueKey} key={uniqueKey}
           hover={this.props.selectionIndex === i + customValueOffset}
           customClasses={this.props.customClasses}
           onClick={this._onClick.bind(this, result)}>


### PR DESCRIPTION
Hi!
Today I found a problem in case when collection consists of elements with no unique displayOption. I've been got an exception from React about that.
This small PR will add unique key for each filtered item.
![2015-07-14 14-30-25 react gameminer](https://cloud.githubusercontent.com/assets/1788245/8672414/bd2c0a6a-2a36-11e5-9504-5f3df100dba5.png)
