### PR TITLE
add `value` option to set typeahead input's value

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Default: []
 
 An array supplied to the filtering function. Can be a list of strings or a list of arbitrary objects. In the latter case, `filterOption` and `displayOption` should be provided.
 
+#### props.defaultValue
+
+Type: `String`
+
+A default value used when the component has no value. If it matches any options a option list will show.
+
+#### props.value
+
+Type: `String`
+
+Specify a value for the text input.
+
 #### props.maxVisible
 
 Type: `Number`

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -27,6 +27,7 @@ var Typeahead = React.createClass({
     options: React.PropTypes.array,
     allowCustomValues: React.PropTypes.number,
     defaultValue: React.PropTypes.string,
+    value: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     textarea: React.PropTypes.bool,
     inputProps: React.PropTypes.object,
@@ -56,6 +57,7 @@ var Typeahead = React.createClass({
       customClasses: {},
       allowCustomValues: 0,
       defaultValue: "",
+      value: null,
       placeholder: "",
       textarea: false,
       inputProps: {},
@@ -75,10 +77,10 @@ var Typeahead = React.createClass({
       visible: this.getOptionsForValue(this.props.defaultValue, this.props.options),
 
       // This should be called something else, "entryValue"
-      entryValue: this.props.defaultValue,
+      entryValue: this.props.value || this.props.defaultValue,
 
       // A valid typeahead value
-      selection: null,
+      selection: this.props.value,
 
       // Index of the selection
       selectionIndex: null

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -330,6 +330,18 @@ describe('Typeahead Component', function() {
       });
     });
 
+    context('value', function() {
+      it('should set input value', function() {
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+          value={ 'John' }
+        />);
+
+        var input = component.refs.entry.getDOMNode();
+        assert.equal(input.value, 'John');
+      });
+    });
+
     context('onKeyDown', function() {
       it('should bind to key events on the input', function() {
         var component = TestUtils.renderIntoDocument(<Typeahead


### PR DESCRIPTION
Allow user set input's value explicitly so it's more useful in 'edit' scenario.

More discussion see https://github.com/fmoo/react-typeahead/pull/82