### PR TITLE
Use upstream keydown handler if the user is pressing shift

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -261,8 +261,9 @@ var Typeahead = React.createClass({
 
   _onKeyDown: function(event) {
     // If there are no visible elements, don't perform selector navigation.
-    // Just pass this up to the upstream onKeydown handler
-    if (!this._hasHint()) {
+    // Just pass this up to the upstream onKeydown handler.
+    // Also skip if the user is pressing the shift key, since none of our handlers are looking for shift
+    if (!this._hasHint() || event.shiftKey) {
       return this.props.onKeyDown(event);
     }
 


### PR DESCRIPTION
I would like to allow the user to be able to shift-tab to navigate backwards from a Typeahead input. However, the _onKeyDown handler was capturing it as a "tab". 

Since none of the built in handlers are looking for "shift", I fixed this issue by passing the keyDown event directly up to the handler if the shift key is pressed. 