### PR TITLE
option to not prevent key events

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -31,6 +31,7 @@ var Typeahead = React.createClass({
     placeholder: React.PropTypes.string,
     textarea: React.PropTypes.bool,
     inputProps: React.PropTypes.object,
+    preventKeyEvents: React.PropTypes.bool,
     onOptionSelected: React.PropTypes.func,
     onChange: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
@@ -66,6 +67,7 @@ var Typeahead = React.createClass({
       placeholder: "",
       textarea: false,
       inputProps: {},
+      preventKeyEvents: true,
       onOptionSelected: function(option) {},
       onChange: function(event) {},
       onKeyDown: function(event) {},
@@ -277,7 +279,9 @@ var Typeahead = React.createClass({
       return this.props.onKeyDown(event);
     }
     // Don't propagate the keystroke back to the DOM/browser
-    event.preventDefault();
+    if (this.props.preventKeyEvents) {
+      event.preventDefault();
+    }
   },
 
   componentWillReceiveProps: function(nextProps) {


### PR DESCRIPTION
Created a new prop to enable/disable keyDown default prevention. In my case having it as false works great so when a user tabs the field gets populated with the first visible option and it jumps right to the next field.