### PR TITLE
Change prop name in README from selectedIndex to selectionIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This component receives the following props :
 ##### Created or modified
 - `props.options`
   - This is the Typeahead's `props.options` filtered and limited to `Typeahead.props.maxVisible`.
-- `props.selectedIndex`
+- `props.selectionIndex`
   - The index of the highlighted option for rendering
 
 


### PR DESCRIPTION
It turns out that the actual prop passed into the custom list component is not `selectedIndex`, but `selectionIndex`

See the default one:
https://github.com/fmoo/react-typeahead/blob/master/src/typeahead/selector.js#L18