### PR TITLE
Short circuit updating visible when entry is empty

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -349,9 +349,8 @@ var Typeahead = React.createClass({
         mapper = IDENTITY_FN;
       }
       return function(value, options) {
-        var transformedOptions = options.map(mapper);
         return fuzzy
-          .filter(value, transformedOptions)
+          .filter(value, options, {extract: mapper})
           .map(function(res) { return options[res.index]; });
       };
     }

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -9,6 +9,7 @@ var fuzzy = require('fuzzy');
 var classNames = require('classnames');
 
 var IDENTITY_FN = function(input) { return input; };
+var SHOULD_SEARCH_VALUE = function(input) { return input && input.trim().length > 0; };
 var _generateAccessor = function(field) {
   return function(object) { return object[field]; };
 };
@@ -95,6 +96,7 @@ var Typeahead = React.createClass({
   },
 
   getOptionsForValue: function(value, options) {
+    if (!SHOULD_SEARCH_VALUE(value)) { return []; }
     var filterOptions = this._generateFilterFunction();
     var result = filterOptions(value, options);
     if (this.props.maxVisible) {


### PR DESCRIPTION
@thehuey, 

Here's a PR that includes a benchmark test. It's run by calling `npm run benchmark`.

This is the output I get:

```
running with 10000 items
original x 38.72 ops/sec ±1.35% (52 runs sampled)
short circuit x 6,076 ops/sec ±1.91% (85 runs sampled)
Fastest is short circuit
```

The effect is dramatic. And it gets much more dramatic the more items in the list.

I don't know if you want to add the option `searchOnBlankValue` or not, but I needed it to run the benchmark.

Addresses #124.