### PR TITLE
Reset the index

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -186,6 +186,7 @@ var Typeahead = React.createClass({
     var value = this.refs.entry.getDOMNode().value;
     this.setState({visible: this.getOptionsForValue(value, this.props.options),
                    selection: null,
+                   selectionIndex: 0,
                    entryValue: value});
   },
 


### PR DESCRIPTION
Fixes the bug where if the rendered options list is shorter than the
previous one, you don’t have to use the up and down arrows to find a
selectable option again because the index didn’t reset.
