### PR TITLE
Allow react 0.14 release candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fuzzy": "^0.1.0"
   },
   "peerDependencies": {
-    "react": ">= 0.13.0"
+    "react": ">=0.13.0 || ^0.14.0-rc1"
   },
   "main": "lib/react-typeahead.js",
   "devDependencies": {


### PR DESCRIPTION
Peer dependency requirements break when using react `0.14.0-rc1`. This PR allows for the release candidate to be used, while still allowing react `0.13` as a peer dependency.