### PR TITLE
Optionally propagate keydown events

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ Default: true
 
 If false, the default classNames are removed from the typeahead.
 
+#### props.propagateKeyDownEvents
+
+Type: `boolean`
+Default: false
+
+If true, allows keyDown events to propagate. This is useful if you want the `tab` key to focus the next element, for example.
+
 #### props.customListComponent
 
 Type: `React Component`

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -51,6 +51,7 @@ var Typeahead = React.createClass({
       React.PropTypes.func
     ]),
     defaultClassNames: React.PropTypes.bool,
+    propagateKeyDownEvents: React.PropTypes.bool,
     customListComponent: React.PropTypes.oneOfType([
       React.PropTypes.element,
       React.PropTypes.func
@@ -75,6 +76,7 @@ var Typeahead = React.createClass({
       onBlur: function(event) {},
       filterOption: null,
       defaultClassNames: true,
+      propagateKeyDownEvents: false,
       customListComponent: TypeaheadSelector
     };
   },
@@ -279,8 +281,10 @@ var Typeahead = React.createClass({
     } else {
       return this.props.onKeyDown(event);
     }
-    // Don't propagate the keystroke back to the DOM/browser
-    event.preventDefault();
+    // By default, don't propagate the keystroke back to the DOM/browser
+    if (!this.props.propagateKeyDownEvents) {
+      event.preventDefault();
+    }
   },
 
   componentWillReceiveProps: function(nextProps) {


### PR DESCRIPTION
so that we can leverage default keydown behaviors provided by the
browser, such as tabbing to the next input.

The default behavior was the previous behavior, so that this is not a
breaking change.