### PR TITLE
feat: add onKeyPress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Type: `Function`
 
 Event handler for the `keyDown` event on the typeahead input.
 
+#### props.onKeyPress
+
+Type: `Function`
+
+Event handler for the `keyPress` event on the typeahead input.
+
 #### props.onKeyUp
 
 Type: `Function`

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -36,6 +36,7 @@ var TypeaheadTokenizer = React.createClass({
     inputProps: React.PropTypes.object,
     onTokenRemove: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
+    onKeyPress: React.PropTypes.func,
     onKeyUp: React.PropTypes.func,
     onTokenAdd: React.PropTypes.func,
     onFocus: React.PropTypes.func,
@@ -73,6 +74,7 @@ var TypeaheadTokenizer = React.createClass({
       filterOption: null,
       displayOption: function(token){return token },
       onKeyDown: function(event) {},
+      onKeyPress: function(event) {},
       onKeyUp: function(event) {},
       onFocus: function(event) {},
       onBlur: function(event) {},
@@ -190,6 +192,7 @@ var TypeaheadTokenizer = React.createClass({
           maxVisible={this.props.maxVisible}
           onOptionSelected={this._addTokenForValue}
           onKeyDown={this._onKeyDown}
+          onKeyPress={this.props.onKeyPress}
           onKeyUp={this.props.onKeyUp}
           onFocus={this.props.onFocus}
           onBlur={this.props.onBlur}

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -35,6 +35,7 @@ var Typeahead = React.createClass({
     onOptionSelected: React.PropTypes.func,
     onChange: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
+    onKeyPress: React.PropTypes.func,
     onKeyUp: React.PropTypes.func,
     onFocus: React.PropTypes.func,
     onBlur: React.PropTypes.func,
@@ -70,6 +71,7 @@ var Typeahead = React.createClass({
       onOptionSelected: function(option) {},
       onChange: function(event) {},
       onKeyDown: function(event) {},
+      onKeyPress: function(event) {},
       onKeyUp: function(event) {},
       onFocus: function(event) {},
       onBlur: function(event) {},
@@ -313,6 +315,7 @@ var Typeahead = React.createClass({
           defaultValue={this.props.defaultValue}
           onChange={this._onChange}
           onKeyDown={this._onKeyDown}
+          onKeyPress={this.props.onKeyPress}
           onKeyUp={this.props.onKeyUp}
           onFocus={this.props.onFocus}
           onBlur={this.props.onBlur}

--- a/test/tokenizer-test.js
+++ b/test/tokenizer-test.js
@@ -108,6 +108,22 @@ describe('TypeaheadTokenizer Component', function() {
       });
     });
 
+    context('onKeyPress', function() {
+      it('should bind to key events on the input', function(done) {
+        var component = TestUtils.renderIntoDocument(<Tokenizer
+          options={ BEATLES }
+          onKeyPress={ function(e) {
+              assert.equal(e.keyCode, 87);
+              done();
+            }
+          }
+        />);
+
+        var input = React.findDOMNode(component.refs.typeahead.refs.entry);
+        TestUtils.Simulate.keyPress(input, { keyCode: 87 });
+      });
+    });
+
     context('onKeyUp', function() {
       it('should bind to key events on the input', function(done) {
         var component = TestUtils.renderIntoDocument(<Tokenizer
@@ -123,6 +139,7 @@ describe('TypeaheadTokenizer Component', function() {
         TestUtils.Simulate.keyUp(input, { keyCode: 87 });
       });
     });
+
     describe('props', function(){
       context('displayOption', function() {
         it('renders simple options verbatim when not specified', function() {

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -357,6 +357,21 @@ describe('Typeahead Component', function() {
       });
     });
 
+    context('onKeyPress', function() {
+      it('should bind to key events on the input', function() {
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+          onKeyPress={ function(e) {
+              assert.equal(e.keyCode, 87);
+            }
+          }
+        />);
+
+        var input = component.refs.entry;
+        TestUtils.Simulate.keyPress(input, { keyCode: 87 });
+      });
+    });
+
     context('onKeyUp', function() {
       it('should bind to key events on the input', function() {
         var component = TestUtils.renderIntoDocument(<Typeahead


### PR DESCRIPTION
I wanted to add onKeyPress events to a `<Typeahead />` component as is often done in inputs and was surprised to see they weren't triggered. Here's an implementation for them (basically the same that onKeyUp's)