### PR TITLE
Custom Option Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ This component receives the following props :
 - `props.selectionIndex`
   - The index of the highlighted option for rendering
 
+#### props.customOptionComponent
+
+Type: `React Component`
+
+A React Component that is rendered within the default list structure. Replaces the `<a>` tag, with a custom component. This allows you to render a different component for different items in a typeahead list.
+
+##### Passed through
+
+- `props.option`
+  - This is the single option which is being mapped over in the list view.
+- `props.children`
+  - This is the result of `displayOption`.
+
 
 ### Typeahead ([Exposed Component Functions][reactecf])
 

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -49,7 +49,11 @@ var TypeaheadTokenizer = React.createClass({
       React.PropTypes.func
     ]),
     maxVisible: React.PropTypes.number,
-    defaultClassNames: React.PropTypes.bool
+    defaultClassNames: React.PropTypes.bool,
+    customOptionComponent: React.PropTypes.oneOfType([
+      React.PropTypes.element,
+      React.PropTypes.func
+    ])
   },
 
   getInitialState: function() {
@@ -185,6 +189,7 @@ var TypeaheadTokenizer = React.createClass({
           inputProps={this.props.inputProps}
           allowCustomValues={this.props.allowCustomValues}
           customClasses={this.props.customClasses}
+          customOptionComponent={this.props.customOptionComponent}
           options={this._getOptionsForTypeahead()}
           defaultValue={this.props.defaultValue}
           maxVisible={this.props.maxVisible}

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -106,10 +106,10 @@ var TypeaheadTokenizer = React.createClass({
     var tokenClasses = {};
     tokenClasses[this.props.customClasses.token] = !!this.props.customClasses.token;
     var classList = classNames(tokenClasses);
-    var result = this.state.selected.map(function(selected) {
+    var result = this.state.selected.map(function(selected, index) {
       var displayString = this.props.displayOption(selected);
       return (
-        <Token key={ displayString } className={classList}
+        <Token key={ displayString + '_' + index } className={classList}
           onRemove={ this._removeTokenForValue }
           object={selected}
           name={ this.props.name }>

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -54,6 +54,10 @@ var Typeahead = React.createClass({
     customListComponent: React.PropTypes.oneOfType([
       React.PropTypes.element,
       React.PropTypes.func
+    ]),
+    customOptionComponent: React.PropTypes.oneOfType([
+      React.PropTypes.element,
+      React.PropTypes.func
     ])
   },
 
@@ -147,6 +151,7 @@ var Typeahead = React.createClass({
         onOptionSelected={this._onOptionSelected}
         customValue={this._getCustomValue()}
         customClasses={this.props.customClasses}
+        customOptionComponent={this.props.customOptionComponent}
         selectionIndex={this.state.selectionIndex}
         defaultClassNames={this.props.defaultClassNames}
         displayOption={this._generateOptionToStringFor(this.props.displayOption)} />

--- a/src/typeahead/option.js
+++ b/src/typeahead/option.js
@@ -14,7 +14,15 @@ var TypeaheadOption = React.createClass({
     customValue: React.PropTypes.string,
     onClick: React.PropTypes.func,
     children: React.PropTypes.string,
-    hover: React.PropTypes.bool
+    hover: React.PropTypes.bool,
+    option: React.PropTypes.oneOfType([
+      React.PropTypes.object,
+      React.PropTypes.string
+    ]),
+    customOptionComponent: React.PropTypes.oneOfType([
+      React.PropTypes.element,
+      React.PropTypes.func
+    ])
   },
 
   getDefaultProps: function() {
@@ -36,12 +44,18 @@ var TypeaheadOption = React.createClass({
     }
 
     var classList = classNames(classes);
+    var CustomComponent = this.props.customOptionComponent;
 
     return (
       <li className={classList} onClick={this._onClick}>
-        <a href="javascript: void 0;" className={this._getClasses()} ref="anchor">
-          { this.props.children }
-        </a>
+        {CustomComponent
+          ? <CustomComponent className={this._getClasses()} ref="anchor" option={this.props.option} >
+              { this.props.children }
+            </CustomComponent>
+          : <a href="javascript: void 0;" className={this._getClasses()} ref="anchor">
+              { this.props.children }
+            </a>}
+        
       </li>
     );
   },

--- a/src/typeahead/selector.js
+++ b/src/typeahead/selector.js
@@ -18,7 +18,11 @@ var TypeaheadSelector = React.createClass({
     selectionIndex: React.PropTypes.number,
     onOptionSelected: React.PropTypes.func,
     displayOption: React.PropTypes.func.isRequired,
-    defaultClassNames: React.PropTypes.bool
+    defaultClassNames: React.PropTypes.bool,
+    customOptionComponent: React.PropTypes.oneOfType([
+      React.PropTypes.element,
+      React.PropTypes.func
+    ])
   },
 
   getDefaultProps: function() {
@@ -61,6 +65,8 @@ var TypeaheadSelector = React.createClass({
         <TypeaheadOption ref={uniqueKey} key={uniqueKey}
           hover={this.props.selectionIndex === i + customValueOffset}
           customClasses={this.props.customClasses}
+          customOptionComponent={this.props.customOptionComponent}
+          option={result}
           onClick={this._onClick.bind(this, result)}>
           { displayString }
         </TypeaheadOption>

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -543,6 +543,42 @@ describe('Typeahead Component', function() {
       });
     });
 
+    context('customOptionComponent', function() {
+      before(function() {
+        OptionComponent = React.createClass({
+          render: function() {
+            return <div>{this.props.children}</div>;
+          }
+        });
+
+        this.OptionComponent = OptionComponent;
+      })
+
+      beforeEach(function() {
+
+        this.component = TestUtils.renderIntoDocument(
+          <Typeahead
+            options={ BEATLES }
+            customOptionComponent={this.OptionComponent}/>
+        );
+      });
+
+      it('should not show the OptionComponent when the input is empty', function() {
+        var results = TestUtils.scryRenderedComponentsWithType(this.component, this.OptionComponent);
+        assert.equal(0, results.length);
+      });
+
+      it('should show the OptionComponent for each input when customOptionComponent is set', function() {
+        var input = this.component.refs.entry.getDOMNode();
+        input.value = "o";
+        TestUtils.Simulate.change(input);
+        var results = TestUtils.scryRenderedComponentsWithType(this.component, this.OptionComponent);
+        // expect 3 = John, Ringo, George
+        assert.equal(3, results.length);
+      });
+
+    });
+
     context('textarea', function() {
       it('should render a <textarea> input', function() {
         var component = TestUtils.renderIntoDocument(<Typeahead


### PR DESCRIPTION
This PR allows an option to pass through just a custom component for each list item. This helps not to create a complete custom list component, but just to make the list more customisable. For example we used this on a project at edenspiekermann to display a list of user results with an avatar, or icon feedback, with different user objects from an API, without having to rebuild the whole list component.

![screen shot 2015-12-15 at 10 15 07](https://cloud.githubusercontent.com/assets/307552/11806652/d90c5e7c-a314-11e5-8849-f41019e3622e.png)
