### PR TITLE
Don't render selector if there are no options to display

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -145,6 +145,7 @@ var Typeahead = React.createClass({
       <this.props.customListComponent
         ref="sel" options={this.state.visible}
         onOptionSelected={this._onOptionSelected}
+        allowCustomValues={this.props.allowCustomValues}
         customValue={this._getCustomValue()}
         customClasses={this.props.customClasses}
         selectionIndex={this.state.selectionIndex}

--- a/src/typeahead/selector.js
+++ b/src/typeahead/selector.js
@@ -13,6 +13,7 @@ var classNames = require('classnames');
 var TypeaheadSelector = React.createClass({
   propTypes: {
     options: React.PropTypes.array,
+    allowCustomValues: React.PropTypes.number,
     customClasses: React.PropTypes.object,
     customValue: React.PropTypes.string,
     selectionIndex: React.PropTypes.number,
@@ -25,6 +26,7 @@ var TypeaheadSelector = React.createClass({
     return {
       selectionIndex: null,
       customClasses: {},
+      allowCustomValues: 0,
       customValue: null,
       onOptionSelected: function(option) { },
       defaultClassNames: true
@@ -32,6 +34,11 @@ var TypeaheadSelector = React.createClass({
   },
 
   render: function() {
+    // Don't render if there are no options to display
+    if (!this.props.options.length && this.props.allowCustomValues <= 0) {
+      return false;
+    }
+
     var classes = {
       "typeahead-selector": this.props.defaultClassNames
     };
@@ -66,7 +73,6 @@ var TypeaheadSelector = React.createClass({
         </TypeaheadOption>
       );
     }, this);
-
 
     return (
       <ul className={classList}>


### PR DESCRIPTION
I originally had the issue of the selector being displayed even when there are no options.

![screenshot 2016-01-22 21 38 53](https://cloud.githubusercontent.com/assets/6979696/12528068/ff643522-c150-11e5-98e9-1259e52041fe.png)

If I am not allowing custom values and type something with no suggestions, the selector is displayed even when the input isn't focused:

![screenshot 2016-01-22 21 40 59](https://cloud.githubusercontent.com/assets/6979696/12528078/68fe7df8-c151-11e5-8327-a0e9f7e5e2c5.png)

I changed it so that the selector component won't display if there are no options available and custom values aren't allowed. I had to send `allowCustomValues` as a prop because it wasn't possible to distinguish whether custom values were allowed or not with the existing `customValue` prop alone. The value of `null` for `customValue` can mean that custom values aren't allowed, the current input has less characters than specified, or the input matches an existing option. 
