### PR TITLE
Fix cWRP to look at new values

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -285,7 +285,7 @@ var Typeahead = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     this.setState({
-      visible: this.getOptionsForValue(this.state.entryValue, nextProps.options)
+      visible: this.getOptionsForValue(nextProps.entryValue, nextProps.options)
     });
   },
 


### PR DESCRIPTION
This change prevents `visible` from being populated on render after entryText has been cleared.

Fixes #162 