### PR TITLE
Make skipping blank searches configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ This component receives the following props :
 - `props.selectionIndex`
   - The index of the highlighted option for rendering
 
+#### props.skipBlankSearch
+
+Type: `boolean`
+Default: true
+
+If false, options will still be rendered when there is no value.
 
 ### Typeahead ([Exposed Component Functions][reactecf])
 

--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ This component receives the following props :
 - `props.selectionIndex`
   - The index of the highlighted option for rendering
 
-#### props.skipBlankSearch
+#### props.showOptionsWhenEmpty
 
 Type: `boolean`
-Default: true
+Default: false
 
-If false, options will still be rendered when there is no value.
+If true, options will still be rendered when there is no value.
 
 ### Typeahead ([Exposed Component Functions][reactecf])
 

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -9,7 +9,6 @@ var fuzzy = require('fuzzy');
 var classNames = require('classnames');
 
 var IDENTITY_FN = function(input) { return input; };
-var SHOULD_SEARCH_VALUE = function(input) { return input && input.trim().length > 0; };
 var _generateAccessor = function(field) {
   return function(object) { return object[field]; };
 };
@@ -55,7 +54,7 @@ var Typeahead = React.createClass({
       React.PropTypes.element,
       React.PropTypes.func
     ]),
-    skipBlankSearch: React.PropTypes.bool
+    showOptionsWhenEmpty: React.PropTypes.bool
   },
 
   getDefaultProps: function() {
@@ -77,7 +76,7 @@ var Typeahead = React.createClass({
       filterOption: null,
       defaultClassNames: true,
       customListComponent: TypeaheadSelector,
-      skipBlankSearch: true
+      showOptionsWhenEmpty: false
     };
   },
 
@@ -97,8 +96,14 @@ var Typeahead = React.createClass({
     };
   },
 
+  _shouldSkipSearch: function(input) {
+    var emptyValue = !input || input.trim().length == 0;
+    return !this.props.showOptionsWhenEmpty && emptyValue;
+  },
+
   getOptionsForValue: function(value, options) {
-    if (this.props.skipBlankSearch && !SHOULD_SEARCH_VALUE(value)) { return []; }
+    if (this._shouldSkipSearch(value)) { return []; }
+
     var filterOptions = this._generateFilterFunction();
     var result = filterOptions(value, options);
     if (this.props.maxVisible) {
@@ -134,7 +139,7 @@ var Typeahead = React.createClass({
 
   _renderIncrementalSearchResults: function() {
     // Nothing has been entered into the textbox
-    if (this.props.skipBlankSearch && !this.state.entryValue) {
+    if (this._shouldSkipSearch(this.state.entryValue)) {
       return "";
     }
 

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -54,7 +54,8 @@ var Typeahead = React.createClass({
     customListComponent: React.PropTypes.oneOfType([
       React.PropTypes.element,
       React.PropTypes.func
-    ])
+    ]),
+    skipBlankSearch: React.PropTypes.bool
   },
 
   getDefaultProps: function() {
@@ -75,7 +76,8 @@ var Typeahead = React.createClass({
       onBlur: function(event) {},
       filterOption: null,
       defaultClassNames: true,
-      customListComponent: TypeaheadSelector
+      customListComponent: TypeaheadSelector,
+      skipBlankSearch: true
     };
   },
 
@@ -96,7 +98,7 @@ var Typeahead = React.createClass({
   },
 
   getOptionsForValue: function(value, options) {
-    if (!SHOULD_SEARCH_VALUE(value)) { return []; }
+    if (this.props.skipBlankSearch && !SHOULD_SEARCH_VALUE(value)) { return []; }
     var filterOptions = this._generateFilterFunction();
     var result = filterOptions(value, options);
     if (this.props.maxVisible) {
@@ -132,7 +134,7 @@ var Typeahead = React.createClass({
 
   _renderIncrementalSearchResults: function() {
     // Nothing has been entered into the textbox
-    if (!this.state.entryValue) {
+    if (this.props.skipBlankSearch && !this.state.entryValue) {
       return "";
     }
 

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -565,21 +565,25 @@ describe('Typeahead Component', function() {
       });
     });
 
-    context('skipBlankSearch', function() {
-      it('does not perform a search by default', function() {
-        var component = TestUtils.renderIntoDocument(<Typeahead
-          options={ BEATLES }
-        />);
+    context('showOptionsWhenEmpty', function() {
+      it('do not render options when value is empty by default', function() {
+        var component = TestUtils.renderIntoDocument(
+          <Typeahead
+            options={ BEATLES }
+          />
+        );
 
         var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);
         assert.equal(0, results.length);
       });
 
-      it('does perform a search when set to false', function() {
-        var component = TestUtils.renderIntoDocument(<Typeahead
-          options={ BEATLES }
-          skipBlankSearch={ false }
-        />);
+      it('render options when value is empty when set to true', function() {
+        var component = TestUtils.renderIntoDocument(
+          <Typeahead
+            options={ BEATLES }
+            showOptionsWhenEmpty={ true }
+          />
+        );
 
         var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);
         assert.equal(4, results.length);

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -563,6 +563,27 @@ describe('Typeahead Component', function() {
         var input = component.refs.entry;
         assert.equal(input.tagName.toLowerCase(), 'input');
       });
-    })
+    });
+
+    context('skipBlankSearch', function() {
+      it('does not perform a search by default', function() {
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+        />);
+
+        var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);
+        assert.equal(0, results.length);
+      });
+
+      it('does perform a search when set to false', function() {
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+          skipBlankSearch={ false }
+        />);
+
+        var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);
+        assert.equal(4, results.length);
+      });
+    });
   });
 });


### PR DESCRIPTION
Previously, options do not show when the value is empty. This PR adds a prop `skipBlankSearch` that allows that behavior to be configurable.

By default, options will still not render when the value is empty.