### PR TITLE
Allowing custom tokenizer token values

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,16 @@ Type: `Function`
 
 A function to filter the provided `options` based on the current input value. For each option, receives `(inputValue, option)`. If not supplied, defaults to [fuzzy string matching](https://github.com/mattyork/fuzzy).
 
+#### props.formInputOption
+
+Type: `String` or `Function`
+
+A function to map an option onto a string to include in HTML forms (see `props.name`). Receives `(option)` as arguments. Must return a string.
+
+If specified as a string, it will interpret it as a field name and use that field from each option object.
+
+If not specified, it will fall back onto the semantics described in `props.displayOption`.
+
 #### props.defaultClassNames
 
 Type: `boolean`

--- a/src/accessor.js
+++ b/src/accessor.js
@@ -1,0 +1,29 @@
+var Accessor = {
+  IDENTITY_FN: function(input) { return input; },
+
+  generateAccessor: function(field) {
+    return function(object) { return object[field]; };
+  },
+
+  generateOptionToStringFor: function(prop) {
+    if (typeof prop === 'string') {
+      return this.generateAccessor(prop);
+    } else if (typeof prop === 'function') {
+      return prop;
+    } else {
+      return this.IDENTITY_FN;
+    }
+  },
+
+  valueForOption: function(option, object) {
+    if (typeof option === 'string') {
+      return object[option];
+    } else if (typeof option === 'function') {
+      return option(object);
+    } else {
+      return object;
+    }
+  },
+};
+
+module.exports = Accessor;

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -76,8 +76,8 @@ var TypeaheadTokenizer = React.createClass({
       inputProps: {},
       defaultClassNames: true,
       filterOption: null,
-      displayOption: function(token){return token },
-      formInputOption: function(token){return token },
+      displayOption: function(token){ return token },
+      formInputOption: null,
       onKeyDown: function(event) {},
       onKeyUp: function(event) {},
       onFocus: function(event) {},
@@ -109,8 +109,8 @@ var TypeaheadTokenizer = React.createClass({
     tokenClasses[this.props.customClasses.token] = !!this.props.customClasses.token;
     var classList = classNames(tokenClasses);
     var result = this.state.selected.map(function(selected) {
-      var value = Accessor.valueForOption(this.props.formInputOption, selected);
       var displayString = Accessor.valueForOption(this.props.displayOption, selected);
+      var value = Accessor.valueForOption(this.props.formInputOption || this.props.displayOption, selected);
       return (
         <Token key={ displayString } className={classList}
           onRemove={ this._removeTokenForValue }

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -2,6 +2,7 @@
  * @jsx React.DOM
  */
 
+var Accessor = require('../accessor');
 var React = require('react');
 var Token = require('./token');
 var KeyEvent = require('../keyevent');
@@ -48,6 +49,10 @@ var TypeaheadTokenizer = React.createClass({
       React.PropTypes.string,
       React.PropTypes.func
     ]),
+    formInputOption: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.func
+    ]),
     maxVisible: React.PropTypes.number,
     defaultClassNames: React.PropTypes.bool
   },
@@ -72,6 +77,7 @@ var TypeaheadTokenizer = React.createClass({
       defaultClassNames: true,
       filterOption: null,
       displayOption: function(token){return token },
+      formInputOption: function(token){return token },
       onKeyDown: function(event) {},
       onKeyUp: function(event) {},
       onFocus: function(event) {},
@@ -103,11 +109,13 @@ var TypeaheadTokenizer = React.createClass({
     tokenClasses[this.props.customClasses.token] = !!this.props.customClasses.token;
     var classList = classNames(tokenClasses);
     var result = this.state.selected.map(function(selected) {
-      var displayString = this.props.displayOption(selected);
+      var value = Accessor.valueForOption(this.props.formInputOption, selected);
+      var displayString = Accessor.valueForOption(this.props.displayOption, selected);
       return (
         <Token key={ displayString } className={classList}
           onRemove={ this._removeTokenForValue }
           object={selected}
+          value={value}
           name={ this.props.name }>
           { displayString }
         </Token>

--- a/src/tokenizer/token.js
+++ b/src/tokenizer/token.js
@@ -18,7 +18,8 @@ var Token = React.createClass({
       React.PropTypes.string,
       React.PropTypes.object,
     ]),
-    onRemove: React.PropTypes.func
+    onRemove: React.PropTypes.func,
+    value: React.PropTypes.string
   },
 
   render: function() {
@@ -46,7 +47,7 @@ var Token = React.createClass({
       <input
         type="hidden"
         name={ this.props.name + '[]' }
-        value={ this.props.object }
+        value={ this.props.value || this.props.object }
       />
     );
   },

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -2,16 +2,12 @@
  * @jsx React.DOM
  */
 
+var Accessor = require('../accessor');
 var React = require('react');
 var TypeaheadSelector = require('./selector');
 var KeyEvent = require('../keyevent');
 var fuzzy = require('fuzzy');
 var classNames = require('classnames');
-
-var IDENTITY_FN = function(input) { return input; };
-var _generateAccessor = function(field) {
-  return function(object) { return object[field]; };
-};
 
 /**
  * A "typeahead", an auto-completing text input
@@ -156,7 +152,7 @@ var Typeahead = React.createClass({
         customClasses={this.props.customClasses}
         selectionIndex={this.state.selectionIndex}
         defaultClassNames={this.props.defaultClassNames}
-        displayOption={this._generateOptionToStringFor(this.props.displayOption)} />
+        displayOption={Accessor.generateOptionToStringFor(this.props.displayOption)} />
     );
   },
 
@@ -176,10 +172,10 @@ var Typeahead = React.createClass({
     var nEntry = this.refs.entry;
     nEntry.focus();
 
-    var displayOption = this._generateOptionToStringFor(this.props.displayOption);
+    var displayOption = Accessor.generateOptionToStringFor(this.props.displayOption);
     var optionString = displayOption(option, 0);
 
-    var formInputOption = this._generateOptionToStringFor(this.props.formInputOption || displayOption);
+    var formInputOption = Accessor.generateOptionToStringFor(this.props.formInputOption || displayOption);
     var formInputOptionString = formInputOption(option);
 
     nEntry.value = optionString;
@@ -352,25 +348,15 @@ var Typeahead = React.createClass({
     } else {
       var mapper;
       if (typeof filterOptionProp === 'string') {
-        mapper = _generateAccessor(filterOptionProp);
+        mapper = Accessor.generateAccessor(filterOptionProp);
       } else {
-        mapper = IDENTITY_FN;
+        mapper = Accessor.IDENTITY_FN;
       }
       return function(value, options) {
         return fuzzy
           .filter(value, options, {extract: mapper})
           .map(function(res) { return options[res.index]; });
       };
-    }
-  },
-
-  _generateOptionToStringFor: function(prop) {
-    if (typeof prop === 'string') {
-      return _generateAccessor(prop);
-    } else if (typeof prop === 'function') {
-      return prop;
-    } else {
-      return IDENTITY_FN;
     }
   },
 

--- a/test/tokenizer-test.js
+++ b/test/tokenizer-test.js
@@ -154,6 +154,46 @@ describe('TypeaheadTokenizer Component', function() {
           var results = simulateTokenInput(component, 'john');
           assert.equal(ReactDOM.findDOMNode(results[0]).textContent, '0 John Lennon');
         });
+
+        it('renders custom option value when specified as a string', function() {
+          var component = TestUtils.renderIntoDocument(<Tokenizer
+            options={ BEATLES_COMPLEX }
+            filterOption='firstName'
+            displayOption='nameWithTitle'
+            formInputOption='lastName'
+          />);
+          var results = simulateTokenInput(component, 'john');
+
+          var entry = component.refs.typeahead.refs.entry;
+          TestUtils.Simulate.keyDown(entry, { keyCode: Keyevent.DOM_VK_DOWN });
+          TestUtils.Simulate.keyDown(entry, { keyCode: Keyevent.DOM_VK_RETURN });
+
+          var tokens = getTokens(component);
+          assert.equal(tokens.length, 1);
+          assert.isDefined(tokens[0]);
+
+          assert.equal(tokens[0].props.value, 'Lennon');
+        });
+
+        it('renders custom option value when specified as a function', function() {
+          var component = TestUtils.renderIntoDocument(<Tokenizer
+            options={ BEATLES_COMPLEX }
+            filterOption='firstName'
+            displayOption='nameWithTitle'
+            formInputOption={ function(o, i) { return o.firstName + ' ' + o.lastName; } }
+          />);
+          results = simulateTokenInput(component, 'john');
+
+          var entry = component.refs.typeahead.refs.entry;
+          TestUtils.Simulate.keyDown(entry, { keyCode: Keyevent.DOM_VK_DOWN });
+          TestUtils.Simulate.keyDown(entry, { keyCode: Keyevent.DOM_VK_RETURN });
+
+          var tokens = getTokens(component);
+          assert.equal(tokens.length, 1);
+          assert.isDefined(tokens[0]);
+
+          assert.equal(tokens[0].props.value, 'John Lennon');
+        });
       });
     });
 

--- a/test/tokenizer-test.js
+++ b/test/tokenizer-test.js
@@ -154,6 +154,27 @@ describe('TypeaheadTokenizer Component', function() {
           var results = simulateTokenInput(component, 'john');
           assert.equal(ReactDOM.findDOMNode(results[0]).textContent, '0 John Lennon');
         });
+      });
+
+      context('formInputOption', function() {
+        it('uses displayOption for the custom option value by default', function() {
+          var component = TestUtils.renderIntoDocument(<Tokenizer
+            options={ BEATLES_COMPLEX }
+            filterOption='firstName'
+            displayOption='nameWithTitle'
+          />);
+          var results = simulateTokenInput(component, 'john');
+
+          var entry = component.refs.typeahead.refs.entry;
+          TestUtils.Simulate.keyDown(entry, { keyCode: Keyevent.DOM_VK_DOWN });
+          TestUtils.Simulate.keyDown(entry, { keyCode: Keyevent.DOM_VK_RETURN });
+
+          var tokens = getTokens(component);
+          assert.equal(tokens.length, 1);
+          assert.isDefined(tokens[0]);
+
+          assert.equal(tokens[0].props.value, 'John Winston Ono Lennon MBE');
+        });
 
         it('renders custom option value when specified as a string', function() {
           var component = TestUtils.renderIntoDocument(<Tokenizer


### PR DESCRIPTION
`Typeahead` has the `formInputOption` property, which can be used to transform a complex option to a form input value. It would be nice to have the same thing for `Tokenizer`.