### PR TITLE
react 14 and 15 testing identified warning in react 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^15.0.1"
   },
   "peerDependencies": {
-    "react": ">= 0.14.0"
+    "react": ">= 0.14"
   },
   "main": "lib/react-typeahead.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "classnames": "^1.2.0",
-    "fuzzy": "^0.1.0"
+    "fuzzy": "^0.1.0",
+    "react": "^15.0.1"
   },
   "peerDependencies": {
     "react": ">= 0.14.0"
@@ -51,8 +52,6 @@
     "literalify": "^0.4.0",
     "lodash": "^2.4.1",
     "mocha": "^1.21.4",
-    "react-addons-test-utils": "^0.14.2",
-    "react-dom": "^0.14.2",
     "react-tools": "^0.13.3",
     "sinon": "^1.10.3",
     "watchify": "^2.2.1"
@@ -63,6 +62,11 @@
     "build-test": "browserify test/main.js -t [ babelify --presets [ react ] ] -o test/bundle.js",
     "build": "browserify ./src/react-typeahead.js -t [ babelify --presets [ react ] ] -t literalify -x react -s ReactTypeahead -o ./dist/react-typeahead.js",
     "watchify": "watchify ./src/react-typeahead.js -t [ babelify --presets [ react ] ] -t literalify -x react -s ReactTypeahead -o ./dist/react-typeahead.js",
+    "react:14" : "npm i react@0.14 react-dom@0.14 react-addons-test-utils@0.14",
+    "react:15" : "npm i react@15 react-dom@15 react-addons-test-utils@15",
+    "test:react:14": "npm run react:14 && npm test",
+    "test:react:15": "npm run react:15 && npm test",
+    "test:all": "npm run test:react:14 && npm run test:react:15",
     "lib": "gulp build",
     "prepublish": "npm run lib"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-typeahead",
-  "version": "1.1.9",
+  "version": "2.0.0",
   "description": "React-based typeahead and typeahead-tokenizer",
   "keywords": [
     "react",
@@ -62,8 +62,8 @@
     "build-test": "browserify test/main.js -t [ babelify --presets [ react ] ] -o test/bundle.js",
     "build": "browserify ./src/react-typeahead.js -t [ babelify --presets [ react ] ] -t literalify -x react -s ReactTypeahead -o ./dist/react-typeahead.js",
     "watchify": "watchify ./src/react-typeahead.js -t [ babelify --presets [ react ] ] -t literalify -x react -s ReactTypeahead -o ./dist/react-typeahead.js",
-    "react:14" : "npm i react@0.14 react-dom@0.14 react-addons-test-utils@0.14",
-    "react:15" : "npm i react@15 react-dom@15 react-addons-test-utils@15",
+    "react:14": "npm i react@0.14 react-dom@0.14 react-addons-test-utils@0.14",
+    "react:15": "npm i react@15 react-dom@15 react-addons-test-utils@15",
     "test:react:14": "npm run react:14 && npm test",
     "test:react:15": "npm run react:15 && npm test",
     "test:all": "npm run test:react:14 && npm run test:react:15",

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -28,7 +28,7 @@ var TypeaheadTokenizer = React.createClass({
     customClasses: React.PropTypes.object,
     allowCustomValues: React.PropTypes.number,
     defaultSelected: React.PropTypes.array,
-    defaultValue: React.PropTypes.string,
+    initialValue: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     inputProps: React.PropTypes.object,
@@ -69,7 +69,7 @@ var TypeaheadTokenizer = React.createClass({
       defaultSelected: [],
       customClasses: {},
       allowCustomValues: 0,
-      defaultValue: "",
+      initialValue: "",
       placeholder: "",
       disabled: false,
       inputProps: {},
@@ -195,7 +195,7 @@ var TypeaheadTokenizer = React.createClass({
           allowCustomValues={this.props.allowCustomValues}
           customClasses={this.props.customClasses}
           options={this._getOptionsForTypeahead()}
-          defaultValue={this.props.defaultValue}
+          initialValue={this.props.initialValue}
           maxVisible={this.props.maxVisible}
           onOptionSelected={this._addTokenForValue}
           onKeyDown={this._onKeyDown}

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -18,7 +18,7 @@ var Typeahead = React.createClass({
     maxVisible: React.PropTypes.number,
     options: React.PropTypes.array,
     allowCustomValues: React.PropTypes.number,
-    defaultValue: React.PropTypes.string,
+    initialValue: React.PropTypes.string,
     value: React.PropTypes.string,
     placeholder: React.PropTypes.string,
     disabled: React.PropTypes.bool,
@@ -56,8 +56,8 @@ var Typeahead = React.createClass({
       options: [],
       customClasses: {},
       allowCustomValues: 0,
-      defaultValue: "",
-      value: null,
+      initialValue: "",
+      value: "",
       placeholder: "",
       disabled: false,
       textarea: false,
@@ -79,10 +79,10 @@ var Typeahead = React.createClass({
   getInitialState: function() {
     return {
       // The currently visible set of options
-      visible: this.getOptionsForValue(this.props.defaultValue, this.props.options),
+      visible: this.getOptionsForValue(this.props.initialValue, this.props.options),
 
       // This should be called something else, "entryValue"
-      entryValue: this.props.value || this.props.defaultValue,
+      entryValue: this.props.value || this.props.initialValue,
 
       // A valid typeahead value
       selection: this.props.value,
@@ -189,7 +189,7 @@ var Typeahead = React.createClass({
   _onTextEntryUpdated: function() {
     var value = this.refs.entry.value;
     this.setState({visible: this.getOptionsForValue(value, this.props.options),
-                   selection: null,
+                   selection: '',
                    entryValue: value});
   },
 
@@ -305,7 +305,6 @@ var Typeahead = React.createClass({
     var classList = classNames(classes);
 
     var InputElement = this.props.textarea ? 'textarea' : 'input';
-
     return (
       <div className={classList}>
         { this._renderHiddenInput() }
@@ -315,7 +314,6 @@ var Typeahead = React.createClass({
           placeholder={this.props.placeholder}
           className={inputClassList}
           value={this.state.entryValue}
-          defaultValue={this.props.defaultValue}
           onChange={this._onChange}
           onKeyDown={this._onKeyDown}
           onKeyPress={this.props.onKeyPress}

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -319,11 +319,11 @@ describe('Typeahead Component', function() {
       });
     });
 
-    context('defaultValue', function() {
+    context('initialValue', function() {
       it('should perform an initial search if a default value is provided', function() {
         var component = TestUtils.renderIntoDocument(<Typeahead
           options={ BEATLES }
-          defaultValue={ 'o' }
+          initialValue={ 'o' }
         />);
 
         var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);


### PR DESCRIPTION
I have identified warnings regarding the new warning added in react 15,

as discussed on react blog and github PR
https://facebook.github.io/react/blog/2016/04/07/react-v15.html#new-deprecations-introduced-with-a-warning

https://github.com/facebook/react/pull/5048

This PR contains how to identify the problem:

new run script:
npm run test:react:15
```
[16:01:26] Starting 'test'...

  Warning: Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled input element and remove one of these props. More info: https://fb.me/react-controlled-components

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․Warning: `value` prop on `input` should not be null. Consider using the empty string to clear the component or `undefined` for uncontrolled components.
․․․․․․
  ․Warning: Textarea elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled textarea and remove one of these props. More info: https://fb.me/react-controlled-components
․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  76 passing (549ms)

[16:01:29] Finished 'test' after 2.52 s
```

npm run test:react:14

```
[16:02:07] Using gulpfile ~/projects/bybox/react-typeahead/gulpfile.js
[16:02:07] Starting 'test'...


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  76 passing (377ms)

[16:02:08] Finished 'test' after 1.74 s
```

I will submit a following PR to show how this will be fixed. 