### PR TITLE
Recalculate visible items on maxVisible prop change

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -97,13 +97,14 @@ var Typeahead = React.createClass({
     return !this.props.showOptionsWhenEmpty && emptyValue;
   },
 
-  getOptionsForValue: function(value, options) {
+  getOptionsForValue: function(value, options, maxVisible) {
     if (this._shouldSkipSearch(value)) { return []; }
 
     var filterOptions = this._generateFilterFunction();
     var result = filterOptions(value, options);
-    if (this.props.maxVisible) {
-      result = result.slice(0, this.props.maxVisible);
+    var maxVisible = maxVisible || this.props.maxVisible;
+    if (maxVisible) {
+      result = result.slice(0, maxVisible);
     }
     return result;
   },
@@ -289,7 +290,7 @@ var Typeahead = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     this.setState({
-      visible: this.getOptionsForValue(this.state.entryValue, nextProps.options)
+      visible: this.getOptionsForValue(this.state.entryValue, nextProps.options, nextProps.maxVisible)
     });
   },
 


### PR DESCRIPTION
This fixes #185 

The `getOptionsForValue` function was using the original value of `maxVisible` when the parent changed the prop. This makes sure that the function uses the new value and displays the correct number of visible items when the component is re-rendered. All tests pass.