### PR TITLE
Remove React as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "dependencies": {
     "classnames": "^1.2.0",
-    "fuzzy": "^0.1.0",
-    "react": "^15.0.1"
+    "fuzzy": "^0.1.0"
   },
   "peerDependencies": {
     "react": ">= 0.14"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fuzzy": "^0.1.0"
   },
   "peerDependencies": {
-    "react": ">= 0.14"
+    "react": ">= 0.15"
   },
   "main": "lib/react-typeahead.js",
   "devDependencies": {


### PR DESCRIPTION
React should only be a peer dependency. When included as a dependency, React will get loaded multiple times and break projects.

```
Uncaught Error: Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. This usually means that you're trying to add a ref to a component that doesn't have an owner (that is, was not created inside of another component's `render` method). Try rendering this component inside of a new top-level component which will hold the ref.
```