### PR TITLE
Add clearSelectionIndex method

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ If true, options will still be rendered when there is no value.
 
 Focuses the typeahead input.
 
+#### typeahead.setEntryText(value)
+
+Sets the value of the input field to `value`.
+
+#### typeahead.clearSelectionIndex
+
+Clears the currently selected option index.
+
 ---
 
 ### Tokenizer(props)

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -202,6 +202,10 @@ var Typeahead = React.createClass({
   },
 
   _onEscape: function() {
+    this.clearSelectionIndex();
+  },
+
+  clearSelectionIndex: function() {
     this.setState({
       selectionIndex: null
     });


### PR DESCRIPTION
Adds `clearSelection` method so calling `_onEscape` is not necessary to clear selectionIndex.

I had a need to clear the selection index, and unless I'm not seeing something, I only found the `_onEscape` method to be able to do that.

Also added short blurb on the `setEntryText` method to README.md.