### PR TITLE
Add more flexible filtering (searchOptions and inputDisplayOptions prop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,15 +323,40 @@ Event handler triggered whenever a token is removed.
 
 Type: `String` or `Function`
 
-A function to map an option onto a string for display in the list. Receives `(option, index)` where index is relative to the results list, not all the options. Must return a string.
+A function to map an option onto a string for display in the list. Receives `(option, index)` where index is relative to the results list, not all the options. Can either return a string or a React component.
 
 If provided as a string, it will interpret it as a field name and use that field from each option object.
 
 #### props.filterOption
 
-Type: `Function`
+Type: `String` or `Function`
 
 A function to filter the provided `options` based on the current input value. For each option, receives `(inputValue, option)`. If not supplied, defaults to [fuzzy string matching](https://github.com/mattyork/fuzzy).
+
+If provided as a string, it will interpret it as a field name and use that field from each option object.
+
+#### props.filterOptions
+
+Type: `Function`
+
+A function to filter, map, and/or sort the provided `options` based on the current input value.
+Receives `(inputValue, options)`.
+If not supplied, defaults to [fuzzy string matching](https://github.com/mattyork/fuzzy).
+
+Note: the function can be used to store other information besides the string in the internal state of the component.
+Make sure to use the `displayOption`, `inputDisplayOption`, and `formInputOption` props to extract/generate the correct format of data that each expects if you do this.
+
+#### props.inputDisplayOption
+
+Type: `String` or `Function`
+
+A function that maps the internal state of the visible options into the value stored in the text value field of the input when an option is selected.
+
+Receives `(option)`.
+
+If provided as a string, it will interpret it as a field name and use that field from each option object.
+
+If no value is set, the input will be set using `displayOption` when an option is selected.
 
 #### props.formInputOption
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ A function to filter the provided `options` based on the current input value. Fo
 
 If provided as a string, it will interpret it as a field name and use that field from each option object.
 
-#### props.filterOptions
+#### props.searchOptions
 
 Type: `Function`
 
@@ -350,7 +350,7 @@ Make sure to use the `displayOption`, `inputDisplayOption`, and `formInputOption
 
 Type: `String` or `Function`
 
-A function that maps the internal state of the visible options into the value stored in the text value field of the input when an option is selected.
+A function that maps the internal state of the visible options into the value stored in the text value field of the visible input when an option is selected.
 
 Receives `(option)`.
 
@@ -362,7 +362,7 @@ If no value is set, the input will be set using `displayOption` when an option i
 
 Type: `String` or `Function`
 
-A function to map an option onto a string to include in HTML forms (see `props.name`). Receives `(option)` as arguments. Must return a string.
+A function to map an option onto a string to include in HTML forms as a hidden field (see `props.name`). Receives `(option)` as arguments. Must return a string.
 
 If specified as a string, it will interpret it as a field name and use that field from each option object.
 

--- a/examples/tokenizer-topcoat.html
+++ b/examples/tokenizer-topcoat.html
@@ -4,8 +4,9 @@
     <meta charset="utf-8">
     <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/topcoat/0.8.0/css/topcoat-mobile-dark.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
     <script src="../node_modules/react/dist/react-with-addons.js"></script>
-    <script src="../node_modules/react/dist/JSXTransformer.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../dist/react-typeahead.js"></script>
   </head>
   <body>
@@ -48,9 +49,7 @@
       <div id="typeahead"></div>
     </div>
 
-    <script type="text/jsx">
-/** @jsx React.DOM */
-
+    <script type="text/babel">
 (function(){
   var req = new XMLHttpRequest();
   req.open('GET', 'files.txt');
@@ -60,7 +59,7 @@
       throw new Error('nope');
     }
 
-    React.render(
+    ReactDOM.render(
       <ReactTypeahead.Tokenizer
         options={req.response.split('\n')}
         allowCustomValues={4}
@@ -78,7 +77,6 @@
 
   req.send();
 })()
-
     </script>
 
   </body>

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -43,6 +43,7 @@ var TypeaheadTokenizer = React.createClass({
       React.PropTypes.string,
       React.PropTypes.func
     ]),
+    searchOptions: React.PropTypes.func,
     displayOption: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.func
@@ -76,6 +77,7 @@ var TypeaheadTokenizer = React.createClass({
       inputProps: {},
       defaultClassNames: true,
       filterOption: null,
+      searchOptions: null,
       displayOption: function(token){ return token },
       formInputOption: null,
       onKeyDown: function(event) {},
@@ -113,12 +115,12 @@ var TypeaheadTokenizer = React.createClass({
       var displayString = Accessor.valueForOption(this.props.displayOption, selected);
       var value = Accessor.valueForOption(this.props.formInputOption || this.props.displayOption, selected);
       return (
-        <Token key={ displayString } className={classList}
-          onRemove={ this._removeTokenForValue }
+        <Token key={displayString} className={classList}
+          onRemove={this._removeTokenForValue}
           object={selected}
           value={value}
-          name={ this.props.name }>
-          { displayString }
+          name={this.props.name}>
+          {displayString}
         </Token>
       );
     }, this);
@@ -207,7 +209,8 @@ var TypeaheadTokenizer = React.createClass({
           onBlur={this.props.onBlur}
           displayOption={this.props.displayOption}
           defaultClassNames={this.props.defaultClassNames}
-          filterOption={this.props.filterOption} />
+          filterOption={this.props.filterOption}
+          searchOptions={this.props.searchOptions} />
       </div>
     );
   }

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -35,7 +35,7 @@ var Typeahead = React.createClass({
       React.PropTypes.string,
       React.PropTypes.func
     ]),
-    filterOptions: React.PropTypes.func,
+    searchOptions: React.PropTypes.func,
     displayOption: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.func
@@ -75,7 +75,7 @@ var Typeahead = React.createClass({
       onFocus: function(event) {},
       onBlur: function(event) {},
       filterOption: null,
-      filterOptions: null,
+      searchOptions: null,
       inputDisplayOption: null,
       defaultClassNames: true,
       customListComponent: TypeaheadSelector,
@@ -107,8 +107,8 @@ var Typeahead = React.createClass({
   getOptionsForValue: function(value, options) {
     if (this._shouldSkipSearch(value)) { return []; }
 
-    var filterOptions = this._generateFilterFunction();
-    var result = filterOptions(value, options);
+    var searchOptions = this._generateSearchFunction();
+    var result = searchOptions(value, options);
     if (this.props.maxVisible) {
       result = result.slice(0, this.props.maxVisible);
     }
@@ -347,14 +347,14 @@ var Typeahead = React.createClass({
     );
   },
 
-  _generateFilterFunction: function() {
-    var filterOptionsProp = this.props.filterOptions;
+  _generateSearchFunction: function() {
+    var searchOptionsProp = this.props.searchOptions;
     var filterOptionProp = this.props.filterOption;
-    if (typeof filterOptionsProp === 'function') {
+    if (typeof searchOptionsProp === 'function') {
       if (filterOptionProp !== null) {
-        console.warn('filterOptions prop is being used, filterOption prop will be ignored');
+        console.warn('searchOptions prop is being used, filterOption prop will be ignored');
       }
-      return filterOptionsProp;
+      return searchOptionsProp;
     } else if (typeof filterOptionProp === 'function') {
       return function(value, options) {
         return options.filter(function(o) { return filterOptionProp(value, o); });

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -35,7 +35,12 @@ var Typeahead = React.createClass({
       React.PropTypes.string,
       React.PropTypes.func
     ]),
+    filterOptions: React.PropTypes.func,
     displayOption: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.func
+    ]),
+    inputDisplayOption: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.func
     ]),
@@ -70,6 +75,8 @@ var Typeahead = React.createClass({
       onFocus: function(event) {},
       onBlur: function(event) {},
       filterOption: null,
+      filterOptions: null,
+      inputDisplayOption: null,
       defaultClassNames: true,
       customListComponent: TypeaheadSelector,
       showOptionsWhenEmpty: false
@@ -173,7 +180,7 @@ var Typeahead = React.createClass({
     var nEntry = this.refs.entry;
     nEntry.focus();
 
-    var displayOption = Accessor.generateOptionToStringFor(this.props.displayOption);
+    var displayOption = Accessor.generateOptionToStringFor(this.props.inputDisplayOption || this.props.displayOption);
     var optionString = displayOption(option, 0);
 
     var formInputOption = Accessor.generateOptionToStringFor(this.props.formInputOption || displayOption);
@@ -341,8 +348,14 @@ var Typeahead = React.createClass({
   },
 
   _generateFilterFunction: function() {
+    var filterOptionsProp = this.props.filterOptions;
     var filterOptionProp = this.props.filterOption;
-    if (typeof filterOptionProp === 'function') {
+    if (typeof filterOptionsProp === 'function') {
+      if (filterOptionProp !== null) {
+        console.warn('filterOptions prop is being used, filterOption prop will be ignored');
+      }
+      return filterOptionsProp;
+    } else if (typeof filterOptionProp === 'function') {
       return function(value, options) {
         return options.filter(function(o) { return filterOptionProp(value, o); });
       };

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -196,6 +196,61 @@ describe('Typeahead Component', function() {
       });
     });
 
+    context('filterOptions', function() {
+      it('maps correctly when specified with map function', function() {
+        var createObject = function(o) {
+          return { len: o.length, orig: o };
+        };
+
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+          filterOptions={ function(inp, opts) { return opts.map(createObject); } }
+          displayOption={ function(o, i) { return 'Score: ' + o.len + ' ' + o.orig; } }
+          inputDisplayOption={ function(o, i) { return o.orig; } }
+        />);
+
+        var results = simulateTextInput(component, 'john');
+        assert.equal(ReactDOM.findDOMNode(results[0]).textContent, 'Score: 4 John');
+      });
+
+      it('can sort displayed items when specified with map function wrapped with sort', function() {
+        var createObject = function(o) {
+          return { len: o.length, orig: o };
+        };
+
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+          filterOptions={ function(inp, opts) { return opts.map(function(o) { return o; }).sort().map(createObject); } }
+          displayOption={ function(o, i) { return 'Score: ' + o.len + ' ' + o.orig; } }
+          inputDisplayOption={ function(o, i) { return o.orig; } }
+        />);
+
+        var results = simulateTextInput(component, 'john');
+        assert.equal(ReactDOM.findDOMNode(results[0]).textContent, 'Score: 6 George');
+      });
+    });
+
+    context('inputDisplayOption', function() {
+      it('displays a different value in input field and in list display', function() {
+        var createObject = function(o) {
+          return { len: o.length, orig: o };
+        };
+
+        var component = TestUtils.renderIntoDocument(<Typeahead
+          options={ BEATLES }
+          filterOptions={ function(inp, opts) { return opts.map(function(o) { return o; }).sort().map(createObject); } }
+          displayOption={ function(o, i) { return 'Score: ' + o.len + ' ' + o.orig; } }
+          inputDisplayOption={ function(o, i) { return o.orig; } }
+        />);
+
+        var results = simulateTextInput(component, 'john');
+        var node = component.refs.entry;
+        TestUtils.Simulate.keyDown(node, { keyCode: Keyevent.DOM_VK_TAB });
+
+        assert.equal(node.value, 'George');
+      });
+    });
+
     context('allowCustomValues', function() {
 
       beforeEach(function() {

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -196,7 +196,7 @@ describe('Typeahead Component', function() {
       });
     });
 
-    context('filterOptions', function() {
+    context('searchOptions', function() {
       it('maps correctly when specified with map function', function() {
         var createObject = function(o) {
           return { len: o.length, orig: o };
@@ -204,7 +204,7 @@ describe('Typeahead Component', function() {
 
         var component = TestUtils.renderIntoDocument(<Typeahead
           options={ BEATLES }
-          filterOptions={ function(inp, opts) { return opts.map(createObject); } }
+          searchOptions={ function(inp, opts) { return opts.map(createObject); } }
           displayOption={ function(o, i) { return 'Score: ' + o.len + ' ' + o.orig; } }
           inputDisplayOption={ function(o, i) { return o.orig; } }
         />);
@@ -220,7 +220,7 @@ describe('Typeahead Component', function() {
 
         var component = TestUtils.renderIntoDocument(<Typeahead
           options={ BEATLES }
-          filterOptions={ function(inp, opts) { return opts.map(function(o) { return o; }).sort().map(createObject); } }
+          searchOptions={ function(inp, opts) { return opts.map(function(o) { return o; }).sort().map(createObject); } }
           displayOption={ function(o, i) { return 'Score: ' + o.len + ' ' + o.orig; } }
           inputDisplayOption={ function(o, i) { return o.orig; } }
         />);
@@ -238,7 +238,7 @@ describe('Typeahead Component', function() {
 
         var component = TestUtils.renderIntoDocument(<Typeahead
           options={ BEATLES }
-          filterOptions={ function(inp, opts) { return opts.map(function(o) { return o; }).sort().map(createObject); } }
+          searchOptions={ function(inp, opts) { return opts.map(function(o) { return o; }).sort().map(createObject); } }
           displayOption={ function(o, i) { return 'Score: ' + o.len + ' ' + o.orig; } }
           inputDisplayOption={ function(o, i) { return o.orig; } }
         />);


### PR DESCRIPTION
Related to:
https://github.com/fmoo/react-typeahead/issues/42
https://github.com/fmoo/react-typeahead/issues/83

### New prop: *searchOptions*
Right now react-typeahead doesn't allow you to provide a way to do complex filtering on the options provided. This PR adds a new prop called `searchOptions` that allows the user to sort, filter, and map the results in any way necessary.

The default fuzzy search gets access to more advanced functionality than `filterOption` provides, the main purpose of this PR is to allow users to access that functionality.

I needed this functionality to provide information to the `displayOption` prop about which characters were being matched in a fuzzy search, but in order to save that information, the best way would be to have some metadata stored with the results. Providing a mapping function in `searchOptions` that stores the score, matched characters, and the original string allows you to display the values in the dropdown however you want. The `inputDisplayOption` allows you to save a different value in the input field when an option is selected.

### Example usage
<img width="485" alt="example-usage" src="https://cloud.githubusercontent.com/assets/930169/15332313/1ab63a90-1c33-11e6-9ac8-eb70234c5bb9.png">

### Changes to *_onOptionSelected*
I made `inputDisplayOption` the default (if it exists) for the value that gets set in `_onOptionSelected` to be the `entryValue`, with the same fallback to `displayOption` that already existed.

The value that gets set in the 'selection' uses `formInputOption` first, then `inputDisplayOption`, and finally `displayOption` if the other two aren't provided.

I wanted to maintain backwards compatibility, but there is some argument to be made that the two options might not both be necessary. On the other hand, one updates the visible text input value, the other updates the hidden value, both are useful.


### Misc notes
If `searchOptions` is provided, `filterOption` will not be used, so it warns the user of that. This warning could be removed, though.


I think this addition to react-typeahead paves the way for really interesting functionality.