### PR TITLE
Show when showOptionsWhenEmpty is true only if the input is focused

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -90,12 +90,17 @@ var Typeahead = React.createClass({
       // Index of the selection
       selectionIndex: null,
 
+      // Keep track of the focus state of the input element, to determine
+      // whether to show options when empty (if showOptionsWhenEmpty is true)
       isFocused: false,
     };
   },
 
   _shouldSkipSearch: function(input) {
     var emptyValue = !input || input.trim().length == 0;
+
+    // this.state must be checked because it may not be defined yet if this function
+    // is called from within getInitialState
     var isFocused = this.state && this.state.isFocused;
     return !(this.props.showOptionsWhenEmpty && isFocused) && emptyValue;
   },

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -88,13 +88,16 @@ var Typeahead = React.createClass({
       selection: this.props.value,
 
       // Index of the selection
-      selectionIndex: null
+      selectionIndex: null,
+
+      isFocused: false,
     };
   },
 
   _shouldSkipSearch: function(input) {
     var emptyValue = !input || input.trim().length == 0;
-    return !this.props.showOptionsWhenEmpty && emptyValue;
+    var isFocused = this.state && this.state.isFocused;
+    return !(this.props.showOptionsWhenEmpty && isFocused) && emptyValue;
   },
 
   getOptionsForValue: function(value, options) {
@@ -318,12 +321,30 @@ var Typeahead = React.createClass({
           onKeyDown={this._onKeyDown}
           onKeyPress={this.props.onKeyPress}
           onKeyUp={this.props.onKeyUp}
-          onFocus={this.props.onFocus}
-          onBlur={this.props.onBlur}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
         />
         { this._renderIncrementalSearchResults() }
       </div>
     );
+  },
+
+  _onFocus: function(event) {
+    this.setState({isFocused: true}, function () {
+      this._onTextEntryUpdated();
+    }.bind(this));
+    if ( this.props.onFocus ) {
+      return this.props.onFocus(event);
+    }
+  },
+
+  _onBlur: function(event) {
+    this.setState({isFocused: false}, function () {
+      this._onTextEntryUpdated();
+    }.bind(this));
+    if ( this.props.onBlur ) {
+      return this.props.onBlur(event);
+    }
   },
 
   _renderHiddenInput: function() {

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -592,7 +592,7 @@ describe('Typeahead Component', function() {
         assert.equal(0, results.length);
       });
 
-      it('render options when value is empty when set to true', function() {
+      it('do not render options when value is empty when set to true and not focused', function() {
         var component = TestUtils.renderIntoDocument(
           <Typeahead
             options={ BEATLES }
@@ -600,6 +600,19 @@ describe('Typeahead Component', function() {
           />
         );
 
+        var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);
+        assert.equal(0, results.length);
+      });
+
+      it('render options when value is empty when set to true and focused', function() {
+        var component = TestUtils.renderIntoDocument(
+          <Typeahead
+            options={ BEATLES }
+            showOptionsWhenEmpty={ true }
+          />
+        );
+
+        TestUtils.Simulate.focus(component.refs.entry);
         var results = TestUtils.scryRenderedComponentsWithType(component, TypeaheadOption);
         assert.equal(4, results.length);
       });


### PR DESCRIPTION
There is an config option for `showOptionsWhenEmpty`, but the problem is there is no way to hide the options if you use it. What we really want is to show the options when you click into the input (on focus) if there is no input text.