### PR TITLE
README update: add 'token' to list of customClasses for Tokenizer component

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The name for HTML forms to be used for submitting the tokens' values array.
 #### props.customClasses
 
 Type: `Object`
-Allowed Keys: `input`, `results`, `listItem`, `listAnchor`, `hover`, `typeahead`, `resultsTruncated`
+Allowed Keys: `input`, `results`, `listItem`, `listAnchor`, `hover`, `typeahead`, `resultsTruncated`, `token`
 
 An object containing custom class names for child elements. Useful for
 integrating with 3rd party UI kits.


### PR DESCRIPTION
[In the code for this example](http://wookiehangover.github.io/react-typeahead/examples/tokenizer-topcoat.html), I saw that you can pass a custom class for the `token`.

Wanted to ensure this was reflected in the documentation.

Thanks again for maintaining this very useful component!