### PR TITLE
Adds onMouseDown workaround to TypeaheadOption

### DIFF
--- a/src/typeahead/option.js
+++ b/src/typeahead/option.js
@@ -33,8 +33,11 @@ var TypeaheadOption = React.createClass({
 
     var classList = classNames(classes);
 
+    // For some reason onClick is not fired when clicked on an option
+    // onMouseDown is used here as a workaround of #205 and other
+    // related tickets
     return (
-      <li className={classList} onClick={this._onClick}>
+      <li className={classList} onClick={this._onClick} onMouseDown={this._onClick}>
         <a href="javascript: void 0;" className={this._getClasses()} ref="anchor">
           { this.props.children }
         </a>

--- a/test/typeahead-test.js
+++ b/test/typeahead-test.js
@@ -138,6 +138,27 @@ describe('Typeahead Component', function() {
       });
     });
 
+    describe('mouse controls', function() {
+      // as of React 15.5.4 this does not work
+      xit('mouse click selects an option (click event)', function() {
+        var results = simulateTextInput(this.component, 'o');
+        var secondItem = ReactDOM.findDOMNode(results[1]);
+        var secondItemValue = secondItem.innerText;
+        var node = this.component.refs.entry;
+        TestUtils.Simulate.click(secondItem);
+        assert.equal(node.value, secondItemValue);
+      });
+      // but this one works
+      it('mouse click selects an option (mouseDown event)', function() {
+        var results = simulateTextInput(this.component, 'o');
+        var secondItem = ReactDOM.findDOMNode(results[1]);
+        var secondItemValue = secondItem.innerText;
+        var node = this.component.refs.entry;
+        TestUtils.Simulate.mouseDown(secondItem);
+        assert.equal(node.value, secondItemValue);
+      });
+    });
+
     describe('component functions', function() {
       beforeEach(function() {
         this.sinon = sinon.sandbox.create();


### PR DESCRIPTION
`onClick` is not fired when clicked on a TypeaheadOption. This adds a `onMouseDown` workaround with the same handler to handle clicks by default.

Adds tests to test `onClick` and `onMouseDown` events, `onClick` test is set as pending until resolved.

Since the whole master branch test suit fails as mentioned in #229, these tests couldn't be verified, but should be fine as soon as the main issue is resolved.