### PR TITLE
fixed problem: list is constantly popping up when Typehead component used with managed `value`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-lib
 node_modules
 .*.swp
 .*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+lib
 node_modules
 .*.swp
 .*.swo

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -310,7 +310,7 @@ var Typeahead = createReactClass({
 
   componentWillReceiveProps: function(nextProps) {
     var searchResults = this.getOptionsForValue(this.state.entryValue, nextProps.options);
-    var showResults = Boolean(searchResults.length);
+    var showResults = Boolean(searchResults.length) && this.state.isFocused;
     this.setState({
       searchResults: searchResults,
       showResults: showResults


### PR DESCRIPTION
fixed problem: list is constantly popping up when Typehead component used with managed `value`, i.e.:

```
class Page extends React.Component{
    render(){
        return <Typehead 
             value={this.state.myValue} 
             onBlur={(e)=>this.setState({myValue: e.target.value}) }
             options={["AAA","BBB"]}
        />`
    }
}
```