### PR TITLE
Add option to clear typeahead on select option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Type: `Boolean`
 
 Set to `true` to use a `<textarea>` element rather than an `<input>` element
 
+#### props.clearOnSelect
+
+Type: `Boolean`
+
+Set to `true` to use clear the `<input>` or `<textarea>` element after selecting an option
+
 #### props.inputProps
 
 Type: `Object`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-typeahead",
-  "version": "2.0.0-alpha.7",
+  "name": "@brodrickchilds/react-typeahead",
+  "version": "2.0.14",
   "description": "React-based typeahead and typeahead-tokenizer",
   "keywords": [
     "react",
@@ -9,9 +9,9 @@
     "autocomplete",
     "react-component"
   ],
-  "homepage": "https://github.com/fmoo/react-typeahead",
+  "homepage": "https://github.com/BrodrickChilds/react-typeahead",
   "bugs": {
-    "url": "https://github.com/fmoo/react-typeahead/issues",
+    "url": "https://github.com/BrodrickChilds/react-typeahead/issues",
     "email": "ruibalp@gmail.com"
   },
   "license": "ISC",
@@ -29,7 +29,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/fmoo/react-typeahead.git"
+    "url": "https://github.com/BrodrickChilds/react-typeahead"
   },
   "dependencies": {
     "classnames": "^1.2.0",

--- a/src/react-typeahead.js
+++ b/src/react-typeahead.js
@@ -1,7 +1,9 @@
 var Typeahead = require('./typeahead');
 var Tokenizer = require('./tokenizer');
+var TypeaheadSelector = require('./typeahead/selector')
 
 module.exports = {
   Typeahead: Typeahead,
-  Tokenizer: Tokenizer
+  Tokenizer: Tokenizer,
+  TypeaheadSelector: TypeaheadSelector
 };

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -26,6 +26,7 @@ var Typeahead = createReactClass({
     placeholder: PropTypes.string,
     disabled: PropTypes.bool,
     textarea: PropTypes.bool,
+    clearOnSelect: PropTypes.bool,
     inputProps: PropTypes.object,
     onOptionSelected: PropTypes.func,
     onChange: PropTypes.func,
@@ -69,6 +70,7 @@ var Typeahead = createReactClass({
       placeholder: "",
       disabled: false,
       textarea: false,
+      clearOnSelect: false,
       inputProps: {},
       onOptionSelected: function(option) {},
       onChange: function(event) {},
@@ -199,11 +201,14 @@ var Typeahead = createReactClass({
     var formInputOption = Accessor.generateOptionToStringFor(this.props.formInputOption || displayOption);
     var formInputOptionString = formInputOption(option);
 
-    nEntry.value = optionString;
-    this.setState({searchResults: this.getOptionsForValue(optionString, this.props.options),
-                   selection: formInputOptionString,
-                   entryValue: optionString,
-                   showResults: false});
+    var valueAfterSelect = this.props.clearOnSelect ? '' : optionString;
+    var selectionAfterSelect = this.props.clearOnSelect ? '' : formInputOptionString;
+
+    nEntry.value = valueAfterSelect;
+    this.setState({searchResults: this.getOptionsForValue(valueAfterSelect, this.props.options),
+                   selection: selectionAfterSelect,
+                   entryValue: valueAfterSelect,
+                   showResults: !!this.props.clearOnSelect});
     return this.props.onOptionSelected(option, event);
   },
 
@@ -310,7 +315,7 @@ var Typeahead = createReactClass({
 
   componentWillReceiveProps: function(nextProps) {
     var searchResults = this.getOptionsForValue(this.state.entryValue, nextProps.options);
-    var showResults = Boolean(searchResults.length) && this.state.isFocused;
+    var showResults = !!this.props.clearOnSelect || (Boolean(searchResults.length) && this.state.isFocused);
     this.setState({
       searchResults: searchResults,
       showResults: showResults


### PR DESCRIPTION
Similar to #108 but a bit more basic.  

We're using the typeahead component as a part of a custom multiselect form, where we don't want the values to appear as tokens but rather in another place in the form where you can interact with them.  Anyways, this allows a straightforward way to clear the input after selecting an option.

Thanks!