### PR TITLE
Click Outside should Close Options list

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -360,7 +360,7 @@ var Typeahead = createReactClass({
   },
 
   _onBlur: function(event) {
-    this.setState({isFocused: false}, function () {
+    this.setState({isFocused: false, showResults: false}, function () {
       this._onTextEntryUpdated();
     }.bind(this));
     if ( this.props.onBlur ) {


### PR DESCRIPTION
**Basic Typeahead with Topcoat**

Edit _onBlur function setting showResults to False to hide Options Menu

Issue #241