### PR TITLE
closes typeahead hint on blur

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -360,7 +360,7 @@ var Typeahead = createReactClass({
   },
 
   _onBlur: function(event) {
-    this.setState({isFocused: false}, function () {
+    this.setState({isFocused: false, showResults: false}, function () {
       this._onTextEntryUpdated();
     }.bind(this));
     if ( this.props.onBlur ) {


### PR DESCRIPTION
The functionality seems like it should be the opposite of onFocus, if this doesn't work maybe I can add an extra prop. right now I don't think there is a good way to close the typeAhead without picking an option. Let me know if I am missing something

ref: 
#169