### PR TITLE
hardcoding className of x <a> tag under Token to typeahead-token-close

### DIFF
--- a/src/tokenizer/token.js
+++ b/src/tokenizer/token.js
@@ -55,7 +55,7 @@ var Token = createReactClass({
       return "";
     }
     return (
-      <a className={this.props.className || "typeahead-token-close"} href="#" onClick={function(event) {
+      <a className="typeahead-token-close" href="#" onClick={function(event) {
           this.props.onRemove(this.props.object);
           event.preventDefault();
         }.bind(this)}>&#x00d7;</a>


### PR DESCRIPTION
value of token key passed under customClasses for Tokenizer is being used as the className for Token component and also for the <a> tag that renders with a close action.

This is wrong . the same class name will be used for both parent and child which screws up the design.
Please separate them.

https://github.com/fmoo/react-typeahead/blob/master/src/tokenizer/token.js

https://github.com/wookiehangover/react-typeahead who has forked your original repo has hardcoded the className of
to typeahead-token-close in https://github.com/wookiehangover/react-typeahead/blob/master/src/tokenizer/token.js.
